### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -13,6 +13,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
   project:
     name: "syssi.esphome-pipsolar@main"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -66,101 +66,101 @@ sensor:
     pipsolar_id: inverter0
     # QPIRI
 #    grid_rating_voltage:
-#      name: "${name} grid_rating_voltage"
+#      name: "grid_rating_voltage"
 #    grid_rating_current:
-#      name: "${name} grid_rating_current"
+#      name: "grid_rating_current"
 #    ac_output_rating_voltage:
-#      name: "${name} ac_output_rating_voltage"
+#      name: "ac_output_rating_voltage"
 #    ac_output_rating_frequency:
-#      name: "${name} ac_output_rating_frequency"
+#      name: "ac_output_rating_frequency"
 #    ac_output_rating_current:
-#      name: "${name} ac_output_rating_current"
+#      name: "ac_output_rating_current"
 #    ac_output_rating_apparent_power:
-#      name: "${name} ac_output_rating_apparent_power"
+#      name: "ac_output_rating_apparent_power"
 #    ac_output_rating_active_power:
-#      name: "${name} ac_output_rating_active_power"
+#      name: "ac_output_rating_active_power"
 #    battery_rating_voltage:
-#      name: "${name} battery_rating_voltage"
+#      name: "battery_rating_voltage"
 #    battery_recharge_voltage:
-#      name: "${name} battery_recharge_voltage"
+#      name: "battery_recharge_voltage"
 #    battery_under_voltage:
-#      name: "${name} battery_under_voltage"
+#      name: "battery_under_voltage"
 #    battery_bulk_voltage:
-#      name: "${name} battery_bulk_voltage"
+#      name: "battery_bulk_voltage"
 #    battery_float_voltage:
-#      name: "${name} battery_float_voltage"
+#      name: "battery_float_voltage"
 #    battery_type:
-#      name: "${name} battery_type"
+#      name: "battery_type"
 #    current_max_ac_charging_current:
-#      name: "${name} current_max_ac_charging_current"
+#      name: "current_max_ac_charging_current"
 #    current_max_charging_current:
-#      name: "${name} current_max_charging_current"
+#      name: "current_max_charging_current"
 #    input_voltage_range:
-#      name: "${name} input_voltage_range"
+#      name: "input_voltage_range"
 #    output_source_priority:
-#      name: "${name} output_source_priority"
+#      name: "output_source_priority"
 #    charger_source_priority:
-#      name: "${name} charger_source_priority"
+#      name: "charger_source_priority"
 #    parallel_max_num:
-#      name: "${name} parallel_max_num"
+#      name: "parallel_max_num"
 #    machine_type:
-#      name: "${name} machine_type"
+#      name: "machine_type"
 #    topology:
-#      name: "${name} topology"
+#      name: "topology"
 #    output_mode:
-#      name: "${name} output_mode"
+#      name: "output_mode"
 #    battery_redischarge_voltage:
-#      name: "${name} battery_redischarge_voltage"
+#      name: "battery_redischarge_voltage"
 #    pv_ok_condition_for_parallel:
-#      name: "${name} pv_ok_condition_for_parallel"
+#      name: "pv_ok_condition_for_parallel"
 #    pv_power_balance:
-#      name: "${name} pv_power_balance"
+#      name: "pv_power_balance"
 
     # QPIGS
     grid_voltage:
-      name: "${name} grid_voltage"
+      name: "grid_voltage"
     grid_frequency:
-      name: "${name} grid_frequency"
+      name: "grid_frequency"
     ac_output_voltage:
-      name: "${name} ac_output_voltage"
+      name: "ac_output_voltage"
     ac_output_frequency:
-      name: "${name} ac_output_frequency"
+      name: "ac_output_frequency"
     ac_output_apparent_power:
-      name: "${name} ac_output_apparent_power"
+      name: "ac_output_apparent_power"
     ac_output_active_power:
-      name: "${name} ac_output_active_power"
+      name: "ac_output_active_power"
     output_load_percent:
-      name: "${name} output_load_percent"
+      name: "output_load_percent"
     bus_voltage:
-      name: "${name} bus_voltage"
+      name: "bus_voltage"
     battery_voltage:
-      name: "${name} battery_voltage"
+      name: "battery_voltage"
     battery_charging_current:
-      name: "${name} battery_charging_current"
+      name: "battery_charging_current"
     battery_capacity_percent:
-      name: "${name} battery_capacity_percent"
+      name: "battery_capacity_percent"
     inverter_heat_sink_temperature:
-      name: "${name} inverter_heat_sink_temperature"
+      name: "inverter_heat_sink_temperature"
     pv_input_current_for_battery:
-      name: "${name} pv_input_current_for_battery"
+      name: "pv_input_current_for_battery"
     pv_input_voltage:
-      name: "${name} pv_input_voltage"
+      name: "pv_input_voltage"
     battery_voltage_scc:
-      name: "${name} battery_voltage_scc"
+      name: "battery_voltage_scc"
     battery_discharge_current:
-      name: "${name} battery_discharge_current"
+      name: "battery_discharge_current"
     battery_voltage_offset_for_fans_on:
-      name: "${name} battery_voltage_offset_for_fans_on"
+      name: "battery_voltage_offset_for_fans_on"
 #    eeprom_version:
-#      name: "${name} eeprom_version"
+#      name: "eeprom_version"
     pv_charging_power:
-      name: "${name} pv_charging_power"
+      name: "pv_charging_power"
 
 text_sensor:
   - platform: pipsolar
     pipsolar_id: inverter0
     device_mode:
-      name: "${name} device_mode"
+      name: "device_mode"
       filters:
         map:
           - P -> Power on mode
@@ -170,67 +170,67 @@ text_sensor:
           - F -> Fault mode
           - D -> Shutdown mode
 #    last_qpigs:
-#      name: "${name} last_qpigs"
+#      name: "last_qpigs"
 #    last_qpiri:
-#      name: "${name} last_qpiri"
+#      name: "last_qpiri"
 #    last_qmod:
-#      name: "${name} last_qmod"
+#      name: "last_qmod"
 #    last_qflag:
-#      name: "${name} last_qflag"
+#      name: "last_qflag"
 
 binary_sensor:
   - platform: pipsolar
     pipsolar_id: inverter0
     add_sbu_priority_version:
-      name: "${name} add_sbu_priority_version"
+      name: "add_sbu_priority_version"
     configuration_status:
-      name: "${name} configuration_status"
+      name: "configuration_status"
 #    scc_firmware_version:
-#      name: "${name} scc_firmware_version"
+#      name: "scc_firmware_version"
     load_status:
-      name: "${name} load_status"
+      name: "load_status"
     battery_voltage_to_steady_while_charging:
-      name: "${name} battery_voltage_to_steady_while_charging"
+      name: "battery_voltage_to_steady_while_charging"
     charging_status:
-      name: "${name} charging_status"
+      name: "charging_status"
     scc_charging_status:
-      name: "${name} scc_charging_status"
+      name: "scc_charging_status"
     ac_charging_status:
-      name: "${name} ac_charging_status"
+      name: "ac_charging_status"
     charging_to_floating_mode:
-      name: "${name} charging_to_floating_mode"
+      name: "charging_to_floating_mode"
     switch_on:
-      name: "${name} switch_on"
+      name: "switch_on"
 #    dustproof_installed:
-#      name: "${name} dustproof_installed"
+#      name: "dustproof_installed"
     silence_buzzer_open_buzzer:
-      name: "${name} silence_buzzer_open_buzzer"
+      name: "silence_buzzer_open_buzzer"
     overload_bypass_function:
-      name: "${name} overload_bypass_function"
+      name: "overload_bypass_function"
     lcd_escape_to_default:
-      name: "${name} lcd_escape_to_default"
+      name: "lcd_escape_to_default"
     overload_restart_function:
-      name: "${name} overload_restart_function"
+      name: "overload_restart_function"
     over_temperature_restart_function:
-      name: "${name} over_temperature_restart_function"
+      name: "over_temperature_restart_function"
 #    backlight_on:
-#      name: "${name} backlight_on"
+#      name: "backlight_on"
 
 switch:
   - platform: pipsolar
     pipsolar_id: inverter0
     output_source_priority_utility:
-      name: "${name} output_source_priority_utility"
+      name: "output_source_priority_utility"
     output_source_priority_solar:
-      name: "${name} output_source_priority_solar"
+      name: "output_source_priority_solar"
     output_source_priority_battery:
-      name: "${name} output_source_priority_battery"
+      name: "output_source_priority_battery"
     input_voltage_range:
-      name: "${name} input_voltage_range"
+      name: "input_voltage_range"
     pv_ok_condition_for_parallel:
-      name: "${name} pv_ok_condition_for_parallel"
+      name: "pv_ok_condition_for_parallel"
     pv_power_balance:
-      name: "${name} pv_power_balance"
+      name: "pv_power_balance"
 
 output:
   - platform: pipsolar

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -64,101 +64,101 @@ sensor:
     pipsolar_id: inverter0
     # QPIRI
 #    grid_rating_voltage:
-#      name: "${name} grid_rating_voltage"
+#      name: "grid_rating_voltage"
 #    grid_rating_current:
-#      name: "${name} grid_rating_current"
+#      name: "grid_rating_current"
 #    ac_output_rating_voltage:
-#      name: "${name} ac_output_rating_voltage"
+#      name: "ac_output_rating_voltage"
 #    ac_output_rating_frequency:
-#      name: "${name} ac_output_rating_frequency"
+#      name: "ac_output_rating_frequency"
 #    ac_output_rating_current:
-#      name: "${name} ac_output_rating_current"
+#      name: "ac_output_rating_current"
 #    ac_output_rating_apparent_power:
-#      name: "${name} ac_output_rating_apparent_power"
+#      name: "ac_output_rating_apparent_power"
 #    ac_output_rating_active_power:
-#      name: "${name} ac_output_rating_active_power"
+#      name: "ac_output_rating_active_power"
 #    battery_rating_voltage:
-#      name: "${name} battery_rating_voltage"
+#      name: "battery_rating_voltage"
 #    battery_recharge_voltage:
-#      name: "${name} battery_recharge_voltage"
+#      name: "battery_recharge_voltage"
 #    battery_under_voltage:
-#      name: "${name} battery_under_voltage"
+#      name: "battery_under_voltage"
 #    battery_bulk_voltage:
-#      name: "${name} battery_bulk_voltage"
+#      name: "battery_bulk_voltage"
 #    battery_float_voltage:
-#      name: "${name} battery_float_voltage"
+#      name: "battery_float_voltage"
 #    battery_type:
-#      name: "${name} battery_type"
+#      name: "battery_type"
 #    current_max_ac_charging_current:
-#      name: "${name} current_max_ac_charging_current"
+#      name: "current_max_ac_charging_current"
 #    current_max_charging_current:
-#      name: "${name} current_max_charging_current"
+#      name: "current_max_charging_current"
 #    input_voltage_range:
-#      name: "${name} input_voltage_range"
+#      name: "input_voltage_range"
 #    output_source_priority:
-#      name: "${name} output_source_priority"
+#      name: "output_source_priority"
 #    charger_source_priority:
-#      name: "${name} charger_source_priority"
+#      name: "charger_source_priority"
 #    parallel_max_num:
-#      name: "${name} parallel_max_num"
+#      name: "parallel_max_num"
 #    machine_type:
-#      name: "${name} machine_type"
+#      name: "machine_type"
 #    topology:
-#      name: "${name} topology"
+#      name: "topology"
 #    output_mode:
-#      name: "${name} output_mode"
+#      name: "output_mode"
 #    battery_redischarge_voltage:
-#      name: "${name} battery_redischarge_voltage"
+#      name: "battery_redischarge_voltage"
 #    pv_ok_condition_for_parallel:
-#      name: "${name} pv_ok_condition_for_parallel"
+#      name: "pv_ok_condition_for_parallel"
 #    pv_power_balance:
-#      name: "${name} pv_power_balance"
+#      name: "pv_power_balance"
 
     # QPIGS
     grid_voltage:
-      name: "${name} grid_voltage"
+      name: "grid_voltage"
     grid_frequency:
-      name: "${name} grid_frequency"
+      name: "grid_frequency"
     ac_output_voltage:
-      name: "${name} ac_output_voltage"
+      name: "ac_output_voltage"
     ac_output_frequency:
-      name: "${name} ac_output_frequency"
+      name: "ac_output_frequency"
     ac_output_apparent_power:
-      name: "${name} ac_output_apparent_power"
+      name: "ac_output_apparent_power"
     ac_output_active_power:
-      name: "${name} ac_output_active_power"
+      name: "ac_output_active_power"
     output_load_percent:
-      name: "${name} output_load_percent"
+      name: "output_load_percent"
     bus_voltage:
-      name: "${name} bus_voltage"
+      name: "bus_voltage"
     battery_voltage:
-      name: "${name} battery_voltage"
+      name: "battery_voltage"
     battery_charging_current:
-      name: "${name} battery_charging_current"
+      name: "battery_charging_current"
     battery_capacity_percent:
-      name: "${name} battery_capacity_percent"
+      name: "battery_capacity_percent"
     inverter_heat_sink_temperature:
-      name: "${name} inverter_heat_sink_temperature"
+      name: "inverter_heat_sink_temperature"
     pv_input_current_for_battery:
-      name: "${name} pv_input_current_for_battery"
+      name: "pv_input_current_for_battery"
     pv_input_voltage:
-      name: "${name} pv_input_voltage"
+      name: "pv_input_voltage"
     battery_voltage_scc:
-      name: "${name} battery_voltage_scc"
+      name: "battery_voltage_scc"
     battery_discharge_current:
-      name: "${name} battery_discharge_current"
+      name: "battery_discharge_current"
     battery_voltage_offset_for_fans_on:
-      name: "${name} battery_voltage_offset_for_fans_on"
+      name: "battery_voltage_offset_for_fans_on"
 #    eeprom_version:
-#      name: "${name} eeprom_version"
+#      name: "eeprom_version"
     pv_charging_power:
-      name: "${name} pv_charging_power"
+      name: "pv_charging_power"
 
 text_sensor:
   - platform: pipsolar
     pipsolar_id: inverter0
     device_mode:
-      name: "${name} device_mode"
+      name: "device_mode"
       filters:
         map:
           - P -> Power on mode
@@ -168,67 +168,67 @@ text_sensor:
           - F -> Fault mode
           - D -> Shutdown mode
 #    last_qpigs:
-#      name: "${name} last_qpigs"
+#      name: "last_qpigs"
 #    last_qpiri:
-#      name: "${name} last_qpiri"
+#      name: "last_qpiri"
 #    last_qmod:
-#      name: "${name} last_qmod"
+#      name: "last_qmod"
 #    last_qflag:
-#      name: "${name} last_qflag"
+#      name: "last_qflag"
 
 binary_sensor:
   - platform: pipsolar
     pipsolar_id: inverter0
     add_sbu_priority_version:
-      name: "${name} add_sbu_priority_version"
+      name: "add_sbu_priority_version"
     configuration_status:
-      name: "${name} configuration_status"
+      name: "configuration_status"
 #    scc_firmware_version:
-#      name: "${name} scc_firmware_version"
+#      name: "scc_firmware_version"
     load_status:
-      name: "${name} load_status"
+      name: "load_status"
     battery_voltage_to_steady_while_charging:
-      name: "${name} battery_voltage_to_steady_while_charging"
+      name: "battery_voltage_to_steady_while_charging"
     charging_status:
-      name: "${name} charging_status"
+      name: "charging_status"
     scc_charging_status:
-      name: "${name} scc_charging_status"
+      name: "scc_charging_status"
     ac_charging_status:
-      name: "${name} ac_charging_status"
+      name: "ac_charging_status"
     charging_to_floating_mode:
-      name: "${name} charging_to_floating_mode"
+      name: "charging_to_floating_mode"
     switch_on:
-      name: "${name} switch_on"
+      name: "switch_on"
 #    dustproof_installed:
-#      name: "${name} dustproof_installed"
+#      name: "dustproof_installed"
     silence_buzzer_open_buzzer:
-      name: "${name} silence_buzzer_open_buzzer"
+      name: "silence_buzzer_open_buzzer"
     overload_bypass_function:
-      name: "${name} overload_bypass_function"
+      name: "overload_bypass_function"
     lcd_escape_to_default:
-      name: "${name} lcd_escape_to_default"
+      name: "lcd_escape_to_default"
     overload_restart_function:
-      name: "${name} overload_restart_function"
+      name: "overload_restart_function"
     over_temperature_restart_function:
-      name: "${name} over_temperature_restart_function"
+      name: "over_temperature_restart_function"
 #    backlight_on:
-#      name: "${name} backlight_on"
+#      name: "backlight_on"
 
 switch:
   - platform: pipsolar
     pipsolar_id: inverter0
     output_source_priority_utility:
-      name: "${name} output_source_priority_utility"
+      name: "output_source_priority_utility"
     output_source_priority_solar:
-      name: "${name} output_source_priority_solar"
+      name: "output_source_priority_solar"
     output_source_priority_battery:
-      name: "${name} output_source_priority_battery"
+      name: "output_source_priority_battery"
     input_voltage_range:
-      name: "${name} input_voltage_range"
+      name: "input_voltage_range"
     pv_ok_condition_for_parallel:
-      name: "${name} pv_ok_condition_for_parallel"
+      name: "pv_ok_condition_for_parallel"
     pv_power_balance:
-      name: "${name} pv_power_balance"
+      name: "pv_power_balance"
 
 output:
   - platform: pipsolar

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -13,6 +13,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
   project:
     name: "syssi.esphome-pipsolar@main"

--- a/tests/esp8266-test-ping.yaml
+++ b/tests/esp8266-test-ping.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
 
 esp8266:

--- a/tests/esp8266-test-pong.yaml
+++ b/tests/esp8266-test-pong.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
 
 esp8266:

--- a/tests/esp8266-test-protocols.yaml
+++ b/tests/esp8266-test-protocols.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
 
 esp8266:

--- a/tests/esp8266-uart-sniffer.yaml
+++ b/tests/esp8266-uart-sniffer.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.6.0
 
 esp8266:


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.