### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/pip2424mse1/output/pipsolar_output.cpp
+++ b/components/pip2424mse1/output/pipsolar_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 
 static const char *const TAG = "pip2424mse1.output";
 
@@ -18,5 +17,4 @@ void PipsolarOutput::write_state(float state) {
     ESP_LOGD(TAG, "Will not write: %s as it is not in list of allowed values", tmp);
   }
 }
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/output/pipsolar_output.h
+++ b/components/pip2424mse1/output/pipsolar_output.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 
 class Pipsolar;
 
@@ -40,5 +39,4 @@ template<typename... Ts> class SetOutputAction : public Action<Ts...> {
   PipsolarOutput *output_;
 };
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/pipsolar.cpp
+++ b/components/pip2424mse1/pipsolar.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "pipsolar_select.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 
 static const char *const TAG = "pip2424mse1";
 
@@ -855,5 +854,4 @@ uint16_t Pipsolar::pipsolar_crc_(uint8_t *msg, uint8_t len) {
   return crc;
 }
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/pipsolar.h
+++ b/components/pip2424mse1/pipsolar.h
@@ -10,8 +10,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 
 class PipsolarSelect;
 
@@ -262,5 +261,4 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
 };
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/pipsolar_select.cpp
+++ b/components/pip2424mse1/pipsolar_select.cpp
@@ -1,8 +1,7 @@
 #include "pipsolar_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 
 static const char *const TAG = "pip2424mse1.select";
 
@@ -31,5 +30,4 @@ void PipsolarSelect::map_and_publish(std::string &value) {
   }
 }
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/pipsolar_select.h
+++ b/components/pip2424mse1/pipsolar_select.h
@@ -7,8 +7,7 @@
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 class Pipsolar;
 
 class PipsolarSelect : public Component, public select::Select {
@@ -28,5 +27,4 @@ class PipsolarSelect : public Component, public select::Select {
   bool optimistic_{false};
 };
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/switch/pipsolar_switch.cpp
+++ b/components/pip2424mse1/switch/pipsolar_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 
 static const char *const TAG = "pip2424mse1.switch";
 
@@ -15,5 +14,4 @@ void PipsolarSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip2424mse1/switch/pipsolar_switch.h
+++ b/components/pip2424mse1/switch/pipsolar_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace pip2424mse1 {
+namespace esphome::pip2424mse1 {
 class Pipsolar;
 class PipsolarSwitch : public switch_::Switch, public Component {
  public:
@@ -24,5 +23,4 @@ class PipsolarSwitch : public switch_::Switch, public Component {
   Pipsolar *parent_;
 };
 
-}  // namespace pip2424mse1
-}  // namespace esphome
+}  // namespace esphome::pip2424mse1

--- a/components/pip8048/output/pipsolar_output.cpp
+++ b/components/pip8048/output/pipsolar_output.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 
 static const char *const TAG = "pip8048.output";
 
@@ -18,5 +17,4 @@ void PipsolarOutput::write_state(float state) {
     ESP_LOGD(TAG, "Will not write: %s as it is not in list of allowed values", tmp);
   }
 }
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/output/pipsolar_output.h
+++ b/components/pip8048/output/pipsolar_output.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 
 class Pipsolar;
 
@@ -40,5 +39,4 @@ template<typename... Ts> class SetOutputAction : public Action<Ts...> {
   PipsolarOutput *output_;
 };
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/pipsolar.cpp
+++ b/components/pip8048/pipsolar.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "pipsolar_select.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 
 static const char *const TAG = "pip8048";
 
@@ -878,5 +877,4 @@ uint16_t Pipsolar::pipsolar_crc_(uint8_t *msg, uint8_t len) {
   return crc;
 }
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/pipsolar.h
+++ b/components/pip8048/pipsolar.h
@@ -10,8 +10,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 
 class PipsolarSelect;
 
@@ -272,5 +271,4 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
 };
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/pipsolar_select.cpp
+++ b/components/pip8048/pipsolar_select.cpp
@@ -1,8 +1,7 @@
 #include "pipsolar_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 
 static const char *const TAG = "pip8048.select";
 
@@ -31,5 +30,4 @@ void PipsolarSelect::map_and_publish(std::string &value) {
   }
 }
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/pipsolar_select.h
+++ b/components/pip8048/pipsolar_select.h
@@ -7,8 +7,7 @@
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 class Pipsolar;
 
 class PipsolarSelect : public Component, public select::Select {
@@ -28,5 +27,4 @@ class PipsolarSelect : public Component, public select::Select {
   bool optimistic_{false};
 };
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/switch/pipsolar_switch.cpp
+++ b/components/pip8048/switch/pipsolar_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 
 static const char *const TAG = "pip8048.switch";
 
@@ -15,5 +14,4 @@ void PipsolarSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048

--- a/components/pip8048/switch/pipsolar_switch.h
+++ b/components/pip8048/switch/pipsolar_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace pip8048 {
+namespace esphome::pip8048 {
 class Pipsolar;
 class PipsolarSwitch : public switch_::Switch, public Component {
  public:
@@ -24,5 +23,4 @@ class PipsolarSwitch : public switch_::Switch, public Component {
   Pipsolar *parent_;
 };
 
-}  // namespace pip8048
-}  // namespace esphome
+}  // namespace esphome::pip8048


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.