### PR TITLE
CI: Run all C++ unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -461,8 +461,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py pip8048
-          script/cpp_unit_test.py pip2424mse1
+          script/cpp_unit_test.py pip8048 pip2424mse1
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0


### PR DESCRIPTION
The C++ unit tests job was running `pip8048` and `pip2424mse1` as separate invocations. Consolidated into a single call.