### PR TITLE
Add pi18 component for PI18 protocol inverters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Do not suggest to move consts
         run: |
-          sed -i 's#if len(uses) < 3:#if len(uses) < 8:#' script/ci-custom.py
+          sed -i 's#if len(uses) < 3:#if len(uses) < 12:#' script/ci-custom.py
           git update-index --assume-unchanged script/ci-custom.py
 
       - name: Run script/ci-custom
@@ -463,7 +463,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py pip8048 pip2424mse1
+          script/cpp_unit_test.py pip8048 pip2424mse1 pi18
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@ Kudos to [@andreashergert1984](https://github.com/andreashergert1984) for the gr
 
 ## Supported devices
 
+The project provides three components for different protocol variants:
+
+### pip8048 (Q-command protocol)
+
 * PIP4048 compatible PV Inverter
+
+### pip2424mse1 (Q-command protocol, extended)
+
+* PIP2424MSE1 and compatible inverters
+
+### pi18 (PI18 protocol, `^P`/`^D` framing)
+
+* MPP Solar LV5048 Hybrid V2
+* SunGoldPower 6048
+* Voltronic InfiniSolar V 4 (3.6 kW / 5.6 kW / 6 kW)
+* AXIOMA 5 kW
+* MppSolar compatible units responding to `^P005GS`
 
 
 ## Requirements

--- a/components/pi18/__init__.py
+++ b/components/pi18/__init__.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
+AUTO_LOAD = ["binary_sensor", "text_sensor", "sensor", "switch", "select", "output"]
+MULTI_CONF = True
+
+CONF_PIPSOLAR_ID = "pipsolar_id"
+
+pipsolar_ns = cg.esphome_ns.namespace("pi18")
+PipsolarComponent = pipsolar_ns.class_("Pipsolar", cg.Component)
+
+PIPSOLAR_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_PIPSOLAR_ID): cv.use_id(PipsolarComponent),
+    }
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2026, 3, 0),
+    cv.Schema({cv.GenerateID(): cv.declare_id(PipsolarComponent)})
+    .extend(cv.polling_component_schema("1s"))
+    .extend(uart.UART_DEVICE_SCHEMA),
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/components/pi18/binary_sensor/__init__.py
+++ b/components/pi18/binary_sensor/__init__.py
@@ -1,0 +1,81 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+
+from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["uart"]
+
+# P005GS binary sensors
+CONF_SETTING_VALUE_CONFIGURATION_STATE = "setting_value_configuration_state"
+
+# P007FLAG binary sensors
+CONF_SILENCE_BUZZER_OPEN_BUZZER = "silence_buzzer_open_buzzer"
+CONF_OVERLOAD_BYPASS_FUNCTION = "overload_bypass_function"
+CONF_LCD_ESCAPE_TO_DEFAULT = "lcd_escape_to_default"
+CONF_OVERLOAD_RESTART_FUNCTION = "overload_restart_function"
+CONF_OVER_TEMPERATURE_RESTART_FUNCTION = "over_temperature_restart_function"
+CONF_BACKLIGHT_ON = "backlight_on"
+CONF_ALARM_ON_WHEN_PRIMARY_SOURCE_INTERRUPT = "alarm_on_when_primary_source_interrupt"
+CONF_FAULT_CODE_RECORD = "fault_code_record"
+CONF_POWER_SAVING = "power_saving"
+
+# P005FWS binary sensors
+CONF_WARNING_LINE_FAIL = "warning_line_fail"
+CONF_WARNING_OUTPUT_CIRCUIT_SHORT = "warning_output_circuit_short"
+CONF_WARNING_OVER_TEMPERATURE = "warning_over_temperature"
+CONF_WARNING_FAN_LOCK = "warning_fan_lock"
+CONF_WARNING_BATTERY_VOLTAGE_HIGH = "warning_battery_voltage_high"
+CONF_WARNING_BATTERY_LOW_ALARM = "warning_battery_low_alarm"
+CONF_WARNING_BATTERY_UNDER_SHUTDOWN = "warning_battery_under_shutdown"
+CONF_WARNING_OVER_LOAD = "warning_over_load"
+CONF_WARNING_EEPROM_FAILED = "warning_eeprom_failed"
+CONF_WARNING_POWER_LIMIT = "warning_power_limit"
+CONF_WARNING_PV1_VOLTAGE_HIGH = "warning_pv1_voltage_high"
+CONF_WARNING_PV2_VOLTAGE_HIGH = "warning_pv2_voltage_high"
+CONF_WARNING_MPPT1_OVERLOAD = "warning_mppt1_overload"
+CONF_WARNING_MPPT2_OVERLOAD = "warning_mppt2_overload"
+CONF_WARNING_SCC1_BATTERY_TOO_LOW_TO_CHARGE = "warning_scc1_battery_too_low_to_charge"
+CONF_WARNING_SCC2_BATTERY_TOO_LOW_TO_CHARGE = "warning_scc2_battery_too_low_to_charge"
+
+TYPES = [
+    CONF_SETTING_VALUE_CONFIGURATION_STATE,
+    CONF_SILENCE_BUZZER_OPEN_BUZZER,
+    CONF_OVERLOAD_BYPASS_FUNCTION,
+    CONF_LCD_ESCAPE_TO_DEFAULT,
+    CONF_OVERLOAD_RESTART_FUNCTION,
+    CONF_OVER_TEMPERATURE_RESTART_FUNCTION,
+    CONF_BACKLIGHT_ON,
+    CONF_ALARM_ON_WHEN_PRIMARY_SOURCE_INTERRUPT,
+    CONF_FAULT_CODE_RECORD,
+    CONF_POWER_SAVING,
+    CONF_WARNING_LINE_FAIL,
+    CONF_WARNING_OUTPUT_CIRCUIT_SHORT,
+    CONF_WARNING_OVER_TEMPERATURE,
+    CONF_WARNING_FAN_LOCK,
+    CONF_WARNING_BATTERY_VOLTAGE_HIGH,
+    CONF_WARNING_BATTERY_LOW_ALARM,
+    CONF_WARNING_BATTERY_UNDER_SHUTDOWN,
+    CONF_WARNING_OVER_LOAD,
+    CONF_WARNING_EEPROM_FAILED,
+    CONF_WARNING_POWER_LIMIT,
+    CONF_WARNING_PV1_VOLTAGE_HIGH,
+    CONF_WARNING_PV2_VOLTAGE_HIGH,
+    CONF_WARNING_MPPT1_OVERLOAD,
+    CONF_WARNING_MPPT2_OVERLOAD,
+    CONF_WARNING_SCC1_BATTERY_TOO_LOW_TO_CHARGE,
+    CONF_WARNING_SCC2_BATTERY_TOO_LOW_TO_CHARGE,
+]
+
+CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
+    {cv.Optional(type): binary_sensor.binary_sensor_schema() for type in TYPES}
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
+    for type in TYPES:
+        if type in config:
+            conf = config[type]
+            var = await binary_sensor.new_binary_sensor(conf)
+            cg.add(getattr(paren, f"set_{type}")(var))

--- a/components/pi18/output/__init__.py
+++ b/components/pi18/output/__init__.py
@@ -1,0 +1,88 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import output
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_VALUE
+
+from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA, pipsolar_ns
+
+DEPENDENCIES = ["pi18"]
+
+PipsolarOutput = pipsolar_ns.class_("PipsolarOutput", output.FloatOutput)
+SetOutputAction = pipsolar_ns.class_("SetOutputAction", automation.Action)
+
+CONF_POSSIBLE_VALUES = "possible_values"
+
+CONF_CURRENT_MAX_AC_CHARGING_CURRENT = "current_max_ac_charging_current"
+CONF_CURRENT_MAX_CHARGING_CURRENT = "current_max_charging_current"
+CONF_BATTERY_BULK_VOLTAGE = "battery_bulk_voltage"
+CONF_BATTERY_FLOAT_VOLTAGE = "battery_float_voltage"
+
+_VOLTAGE_STEPS = [round(v * 0.1, 1) for v in range(480, 585)]
+
+TYPES = {
+    CONF_CURRENT_MAX_AC_CHARGING_CURRENT: (
+        [2, 10, 20, 30, 40, 50, 60, 70, 80, 90],
+        "^S014MUCHGC0,%03d",
+    ),
+    CONF_CURRENT_MAX_CHARGING_CURRENT: (
+        [10, 20, 30, 40, 50, 60, 70, 80, 90],
+        "^S013MCHGC0,%03d",
+    ),
+    # ^S015MCHGVmmm.m,nnn.n — bulk and float share the same command;
+    # the other voltage is left at its current value by the inverter
+    CONF_BATTERY_BULK_VOLTAGE: (
+        _VOLTAGE_STEPS,
+        "^S015MCHGV%04.1f,%04.1f",
+    ),
+    CONF_BATTERY_FLOAT_VOLTAGE: (
+        _VOLTAGE_STEPS,
+        "^S015MCHGV%04.1f,%04.1f",
+    ),
+}
+
+CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(type): output.FLOAT_OUTPUT_SCHEMA.extend(
+            {
+                cv.Required(CONF_ID): cv.declare_id(PipsolarOutput),
+                cv.Optional(CONF_POSSIBLE_VALUES, default=values): cv.All(
+                    cv.ensure_list(cv.positive_float), cv.Length(min=1)
+                ),
+            }
+        )
+        for type, (values, _) in TYPES.items()
+    }
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
+
+    for type, (_, command) in TYPES.items():
+        if type in config:
+            conf = config[type]
+            var = cg.new_Pvariable(conf[CONF_ID])
+            await output.register_output(var, conf)
+            cg.add(var.set_parent(paren))
+            cg.add(var.set_set_command(command))
+            if CONF_POSSIBLE_VALUES in conf:
+                cg.add(var.set_possible_values(conf[CONF_POSSIBLE_VALUES]))
+
+
+@automation.register_action(
+    "output.pi18.set_level",
+    SetOutputAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(CONF_ID),
+            cv.Required(CONF_VALUE): cv.templatable(cv.positive_float),
+        }
+    ),
+)
+async def output_pi18_set_level_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_VALUE], args, float)
+    cg.add(var.set_level(template_))
+    return var

--- a/components/pi18/output/pipsolar_output.cpp
+++ b/components/pi18/output/pipsolar_output.cpp
@@ -1,0 +1,21 @@
+#include "pipsolar_output.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+namespace esphome::pi18 {
+
+static const char *const TAG = "pi18.output";
+
+void PipsolarOutput::write_state(float state) {
+  char tmp[16];
+  snprintf(tmp, sizeof(tmp), this->set_command_, state);
+
+  if (std::find(this->possible_values_.begin(), this->possible_values_.end(), state) != this->possible_values_.end()) {
+    ESP_LOGD(TAG, "Will write: %s out of value %f / %02.0f", tmp, state, state);
+    this->parent_->queue_command(std::string(tmp));
+  } else {
+    ESP_LOGD(TAG, "Will not write: %s as it is not in list of allowed values", tmp);
+  }
+}
+
+}  // namespace esphome::pi18

--- a/components/pi18/output/pipsolar_output.h
+++ b/components/pi18/output/pipsolar_output.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../pipsolar.h"
+#include "esphome/components/output/float_output.h"
+#include "esphome/core/component.h"
+
+#include <vector>
+
+namespace esphome::pi18 {
+
+class Pipsolar;
+
+class PipsolarOutput : public output::FloatOutput {
+ public:
+  PipsolarOutput() {}
+  void set_parent(Pipsolar *parent) { this->parent_ = parent; }
+  void set_set_command(const char *command) { this->set_command_ = command; }
+  void set_set_command(const std::string &command) = delete;
+  void set_possible_values(std::vector<float> possible_values) { this->possible_values_ = std::move(possible_values); }
+  void set_value(float value) { this->write_state(value); }
+
+ protected:
+  void write_state(float state) override;
+  const char *set_command_{nullptr};
+  Pipsolar *parent_;
+  std::vector<float> possible_values_;
+};
+
+template<typename... Ts> class SetOutputAction : public Action<Ts...> {
+ public:
+  SetOutputAction(PipsolarOutput *output) : output_(output) {}
+
+  TEMPLATABLE_VALUE(float, level)
+
+  void play(const Ts &...x) override { this->output_->set_value(this->level_.value(x...)); }
+
+ protected:
+  PipsolarOutput *output_;
+};
+
+}  // namespace esphome::pi18

--- a/components/pi18/pipsolar.cpp
+++ b/components/pi18/pipsolar.cpp
@@ -1,0 +1,707 @@
+#include "pipsolar.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "pipsolar_select.h"
+
+namespace esphome::pi18 {
+
+static const char *const TAG = "pi18";
+
+void Pipsolar::setup() {
+  this->state_ = STATE_IDLE;
+  this->command_start_millis_ = 0;
+}
+
+void Pipsolar::empty_uart_buffer_() {
+  uint8_t buf[64];
+  size_t avail;
+  while ((avail = this->available()) > 0) {
+    if (!this->read_array(buf, std::min(avail, sizeof(buf)))) {
+      break;
+    }
+  }
+}
+
+void Pipsolar::loop() {
+  if (this->state_ == STATE_IDLE) {
+    this->empty_uart_buffer_();
+
+    if (this->send_next_command_()) {
+      return;
+    }
+
+    if (this->send_next_poll_()) {
+      return;
+    }
+
+    return;
+  }
+  if (this->state_ == STATE_COMMAND_COMPLETE) {
+    if (this->check_incoming_length_(4)) {
+      if (this->check_incoming_crc_()) {
+        if (this->read_buffer_[1] == 'A' && this->read_buffer_[2] == 'C' && this->read_buffer_[3] == 'K') {
+          ESP_LOGD(TAG, "command successful");
+        } else {
+          ESP_LOGD(TAG, "command not successful");
+        }
+        this->command_queue_[this->command_queue_position_] = std::string("");
+        this->command_queue_position_ = (command_queue_position_ + 1) % COMMAND_QUEUE_LENGTH;
+        this->state_ = STATE_IDLE;
+      } else {
+        this->command_queue_[this->command_queue_position_] = std::string("");
+        this->command_queue_position_ = (command_queue_position_ + 1) % COMMAND_QUEUE_LENGTH;
+        this->state_ = STATE_IDLE;
+      }
+    } else {
+      ESP_LOGD(TAG, "command %s response length not OK: with length %zu",
+               this->command_queue_[this->command_queue_position_].c_str(), this->read_pos_);
+      this->command_queue_[this->command_queue_position_] = std::string("");
+      this->command_queue_position_ = (command_queue_position_ + 1) % COMMAND_QUEUE_LENGTH;
+      this->state_ = STATE_IDLE;
+    }
+  }
+
+  if (this->state_ == STATE_POLL_CHECKED) {
+    ESP_LOGD(TAG, "poll %s decode", this->enabled_polling_commands_[this->last_polling_command_].command);
+    this->handle_poll_response_(this->enabled_polling_commands_[this->last_polling_command_].identifier,
+                                (const char *) this->read_buffer_);
+    this->state_ = STATE_IDLE;
+    return;
+  }
+
+  if (this->state_ == STATE_POLL_COMPLETE) {
+    if (this->check_incoming_crc_()) {
+      if (this->read_buffer_[0] == '(' && this->read_buffer_[1] == 'N' && this->read_buffer_[2] == 'A' &&
+          this->read_buffer_[3] == 'K') {
+        ESP_LOGD(TAG, "poll %s NACK", this->enabled_polling_commands_[this->last_polling_command_].command);
+        this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
+        this->state_ = STATE_IDLE;
+        return;
+      }
+      this->enabled_polling_commands_[this->last_polling_command_].needs_update = false;
+      this->state_ = STATE_POLL_CHECKED;
+      return;
+    } else {
+      this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
+      this->state_ = STATE_IDLE;
+    }
+  }
+
+  if (this->state_ == STATE_COMMAND || this->state_ == STATE_POLL) {
+    size_t avail = this->available();
+    while (avail > 0) {
+      uint8_t buf[64];
+      size_t to_read = std::min(avail, sizeof(buf));
+      if (!this->read_array(buf, to_read)) {
+        break;
+      }
+      avail -= to_read;
+      bool done = false;
+      for (size_t i = 0; i < to_read; i++) {
+        uint8_t byte = buf[i];
+
+        if (this->read_pos_ >= PIPSOLAR_READ_BUFFER_LENGTH - 1) {
+          this->read_pos_ = 0;
+          this->empty_uart_buffer_();
+          ESP_LOGW(TAG, "response data too long, discarding.");
+          done = true;
+          break;
+        }
+        this->read_buffer_[this->read_pos_] = byte;
+        this->read_pos_++;
+
+        if (byte == 0x0D) {
+          this->read_buffer_[this->read_pos_] = 0;
+          this->empty_uart_buffer_();
+          if (this->state_ == STATE_POLL) {
+            this->state_ = STATE_POLL_COMPLETE;
+          }
+          if (this->state_ == STATE_COMMAND) {
+            this->state_ = STATE_COMMAND_COMPLETE;
+          }
+          done = true;
+          break;
+        }
+      }
+      if (done) {
+        break;
+      }
+    }
+  }
+  if (this->state_ == STATE_COMMAND) {
+    if (millis() - this->command_start_millis_ > esphome::pi18::Pipsolar::COMMAND_TIMEOUT) {
+      const char *command = this->command_queue_[this->command_queue_position_].c_str();
+      this->command_start_millis_ = millis();
+      ESP_LOGD(TAG, "command %s timeout", command);
+      this->command_queue_[this->command_queue_position_] = std::string("");
+      this->command_queue_position_ = (command_queue_position_ + 1) % COMMAND_QUEUE_LENGTH;
+      this->state_ = STATE_IDLE;
+      return;
+    }
+  }
+  if (this->state_ == STATE_POLL) {
+    if (millis() - this->command_start_millis_ > esphome::pi18::Pipsolar::COMMAND_TIMEOUT) {
+      ESP_LOGD(TAG, "poll %s timeout", this->enabled_polling_commands_[this->last_polling_command_].command);
+      this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
+      this->state_ = STATE_IDLE;
+    }
+  }
+}
+
+uint8_t Pipsolar::check_incoming_length_(uint8_t length) {
+  if (this->read_pos_ >= 3 && this->read_pos_ - 3 == length) {
+    return 1;
+  }
+  return 0;
+}
+
+uint8_t Pipsolar::check_incoming_crc_() {
+  if (this->read_pos_ < 3)
+    return 0;
+  uint16_t crc16;
+  crc16 = this->pipsolar_crc_(read_buffer_, read_pos_ - 3);
+  if (((uint8_t) ((crc16) >> 8)) == read_buffer_[read_pos_ - 3] &&
+      ((uint8_t) ((crc16) &0xff)) == read_buffer_[read_pos_ - 2]) {
+    ESP_LOGD(TAG, "CRC OK");
+    read_buffer_[read_pos_ - 1] = 0;
+    read_buffer_[read_pos_ - 2] = 0;
+    read_buffer_[read_pos_ - 3] = 0;
+    return 1;
+  }
+  ESP_LOGD(TAG, "CRC NOK expected: %X %X but got: %X %X", ((uint8_t) ((crc16) >> 8)), ((uint8_t) ((crc16) &0xff)),
+           read_buffer_[read_pos_ - 3], read_buffer_[read_pos_ - 2]);
+  return 0;
+}
+
+bool Pipsolar::send_next_command_() {
+  uint16_t crc16;
+  if (!this->command_queue_[this->command_queue_position_].empty()) {
+    const char *command = this->command_queue_[this->command_queue_position_].c_str();
+    uint8_t byte_command[32];
+    size_t length = this->command_queue_[this->command_queue_position_].length();
+    if (length > sizeof(byte_command)) {
+      ESP_LOGE(TAG, "Command too long: %zu", length);
+      this->command_queue_[this->command_queue_position_].clear();
+      return false;
+    }
+    for (size_t i = 0; i < length; i++) {
+      byte_command[i] = (uint8_t) this->command_queue_[this->command_queue_position_].at(i);
+    }
+    this->state_ = STATE_COMMAND;
+    this->command_start_millis_ = millis();
+    this->empty_uart_buffer_();
+    this->read_pos_ = 0;
+    crc16 = this->pipsolar_crc_(byte_command, length);
+    this->write_str(command);
+    this->write(((uint8_t) ((crc16) >> 8)));
+    this->write(((uint8_t) ((crc16) &0xff)));
+    this->write(0x0D);
+    ESP_LOGD(TAG, "Sending command from queue: %s with length %zu", command, length);
+    return true;
+  }
+  return false;
+}
+
+bool Pipsolar::send_next_poll_() {
+  uint16_t crc16;
+  for (uint8_t i = 0; i < POLLING_COMMANDS_MAX; i++) {
+    this->last_polling_command_ = (this->last_polling_command_ + 1) % POLLING_COMMANDS_MAX;
+    if (this->enabled_polling_commands_[this->last_polling_command_].length == 0) {
+      continue;
+    }
+    if (!this->enabled_polling_commands_[this->last_polling_command_].needs_update) {
+      continue;
+    }
+    this->state_ = STATE_POLL;
+    this->command_start_millis_ = millis();
+    this->empty_uart_buffer_();
+    this->read_pos_ = 0;
+    crc16 = this->pipsolar_crc_(this->enabled_polling_commands_[this->last_polling_command_].command,
+                                this->enabled_polling_commands_[this->last_polling_command_].length);
+    this->write_array(this->enabled_polling_commands_[this->last_polling_command_].command,
+                      this->enabled_polling_commands_[this->last_polling_command_].length);
+    this->write(((uint8_t) ((crc16) >> 8)));
+    this->write(((uint8_t) ((crc16) &0xff)));
+    this->write(0x0D);
+    ESP_LOGD(TAG, "Sending polling command: %s with length %d",
+             this->enabled_polling_commands_[this->last_polling_command_].command,
+             this->enabled_polling_commands_[this->last_polling_command_].length);
+    return true;
+  }
+  return false;
+}
+
+void Pipsolar::queue_command(const std::string &command) {
+  uint8_t next_position = command_queue_position_;
+  for (uint8_t i = 0; i < COMMAND_QUEUE_LENGTH; i++) {
+    uint8_t testposition = (next_position + i) % COMMAND_QUEUE_LENGTH;
+    if (command_queue_[testposition].empty()) {
+      command_queue_[testposition] = command;
+      ESP_LOGD(TAG, "Command queued successfully: %s at position %d", command.c_str(), testposition);
+      return;
+    }
+  }
+  ESP_LOGD(TAG, "Command queue full dropping command: %s", command.c_str());
+}
+
+void Pipsolar::handle_poll_response_(ENUMPollingCommand polling_command, const char *message) {
+  switch (polling_command) {
+    case POLLING_P007PIRI:
+      handle_p007piri_(message);
+      break;
+    case POLLING_P005GS:
+      handle_p005gs_(message);
+      break;
+    case POLLING_P006MOD:
+      handle_p006mod_(message);
+      break;
+    case POLLING_P007FLAG:
+      handle_p007flag_(message);
+      break;
+    case POLLING_P005FWS:
+      handle_p005fws_(message);
+      break;
+    case POLLING_P005ET:
+      handle_p005et_(message);
+      break;
+    case POLLING_P007PGS0:
+      handle_p007pgs0_(message);
+      break;
+    default:
+      break;
+  }
+}
+
+void Pipsolar::handle_poll_error_(ENUMPollingCommand polling_command) {
+  this->handle_poll_response_(polling_command, "");
+}
+
+void Pipsolar::handle_p005gs_(const char *message) {
+  if (this->last_p005gs_)
+    this->last_p005gs_->publish_state(message);
+
+  size_t pos = 0;
+  skip_start_(message, &pos);
+
+  read_sensor_(message, &pos, this->grid_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->grid_frequency_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_frequency_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_apparent_power_);
+  read_sensor_(message, &pos, this->ac_output_active_power_);
+  read_sensor_(message, &pos, this->output_load_percent_);
+  read_sensor_(message, &pos, this->battery_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->battery_voltage_scc_, 0.1f);
+  read_sensor_(message, &pos, this->battery_voltage_scc2_, 0.1f);
+  read_sensor_(message, &pos, this->battery_discharge_current_, -1.0f);
+  read_sensor_(message, &pos, this->battery_charging_current_);
+  read_sensor_(message, &pos, this->battery_capacity_percent_);
+  read_sensor_(message, &pos, this->inverter_heat_sink_temperature_);
+  read_sensor_(message, &pos, this->mppt1_charger_temperature_);
+  read_sensor_(message, &pos, this->mppt2_charger_temperature_);
+  read_sensor_(message, &pos, this->pv1_input_power_);
+  read_sensor_(message, &pos, this->pv2_input_power_);
+  read_sensor_(message, &pos, this->pv1_input_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->pv2_input_voltage_, 0.1f);
+
+  const int config_state = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int mppt1_status = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int mppt2_status = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int load_conn = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int bat_dir = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int dc_ac_dir = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int line_dir = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+
+  this->publish_binary_sensor_(config_state != 0, this->setting_value_configuration_state_);
+  this->publish_mppt_status_(this->mppt1_charger_status_, mppt1_status);
+  this->publish_mppt_status_(this->mppt2_charger_status_, mppt2_status);
+
+  if (this->load_connection_)
+    this->load_connection_->publish_state(load_conn == 1 ? "connect" : "disconnect");
+
+  if (this->battery_power_direction_) {
+    switch (bat_dir) {
+      case 0:
+        this->battery_power_direction_->publish_state("donothing");
+        break;
+      case 1:
+        this->battery_power_direction_->publish_state("charge");
+        break;
+      case 2:
+        this->battery_power_direction_->publish_state("discharge");
+        break;
+      default:
+        break;
+    }
+  }
+  if (this->dc_ac_power_direction_) {
+    switch (dc_ac_dir) {
+      case 0:
+        this->dc_ac_power_direction_->publish_state("donothing");
+        break;
+      case 1:
+        this->dc_ac_power_direction_->publish_state("AC-DC");
+        break;
+      case 2:
+        this->dc_ac_power_direction_->publish_state("DC-AC");
+        break;
+      default:
+        break;
+    }
+  }
+  this->publish_direction_(this->line_power_direction_, line_dir);
+}
+
+void Pipsolar::handle_p007piri_(const char *message) {
+  if (this->last_p007piri_)
+    this->last_p007piri_->publish_state(message);
+
+  size_t pos = 0;
+  skip_start_(message, &pos);
+
+  read_sensor_(message, &pos, this->grid_rating_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->grid_rating_current_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_rating_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_rating_frequency_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_rating_current_, 0.1f);
+  read_sensor_(message, &pos, this->ac_output_rating_apparent_power_);
+  read_sensor_(message, &pos, this->ac_output_rating_active_power_);
+  read_sensor_(message, &pos, this->battery_rating_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->battery_recharge_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->battery_redischarge_voltage_, 0.1f);
+
+  const int bat_under_v_raw = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  if (this->battery_under_voltage_)
+    this->battery_under_voltage_->publish_state(bat_under_v_raw * 0.1f);
+
+  read_sensor_(message, &pos, this->battery_bulk_voltage_, 0.1f);
+  read_sensor_(message, &pos, this->battery_float_voltage_, 0.1f);
+
+  const int bat_type = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int max_ac_charging_i = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int max_charging_i = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int input_v_range = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int out_src_priority = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int charger_src_priority = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int parallel_max = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int machine_type = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int topology = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int output_mode = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int solar_priority = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  const int mppt_string = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+
+  if (this->battery_type_)
+    this->battery_type_->publish_state(bat_type);
+  if (this->current_max_ac_charging_current_)
+    this->current_max_ac_charging_current_->publish_state(max_ac_charging_i);
+  if (this->current_max_charging_current_)
+    this->current_max_charging_current_->publish_state(max_charging_i);
+  if (this->input_voltage_range_)
+    this->input_voltage_range_->publish_state(input_v_range);
+  if (this->output_source_priority_)
+    this->output_source_priority_->publish_state(out_src_priority);
+  if (this->charger_source_priority_)
+    this->charger_source_priority_->publish_state(charger_src_priority);
+  if (this->parallel_max_num_)
+    this->parallel_max_num_->publish_state(parallel_max);
+  if (this->machine_type_)
+    this->machine_type_->publish_state(machine_type);
+  if (this->topology_)
+    this->topology_->publish_state(topology);
+  if (this->output_mode_)
+    this->output_mode_->publish_state(output_mode);
+  if (this->solar_power_priority_)
+    this->solar_power_priority_->publish_state(solar_priority);
+  if (this->mppt_string_)
+    this->mppt_string_->publish_state(mppt_string);
+
+  std::string out_src_str = std::to_string(out_src_priority);             // NOLINT
+  std::string charger_src_str = std::to_string(charger_src_priority);     // NOLINT
+  std::string solar_prio_str = std::to_string(solar_priority);            // NOLINT
+  std::string input_v_range_str = std::to_string(input_v_range);          // NOLINT
+  std::string machine_type_str = std::to_string(machine_type);            // NOLINT
+  std::string max_charging_i_str = std::to_string(max_charging_i);        // NOLINT
+  std::string max_ac_charging_i_str = std::to_string(max_ac_charging_i);  // NOLINT
+  std::string bat_under_v_str = std::to_string(bat_under_v_raw);          // NOLINT
+
+  if (this->output_source_priority_select_)
+    this->output_source_priority_select_->map_and_publish(out_src_str);
+  if (this->charger_source_priority_select_)
+    this->charger_source_priority_select_->map_and_publish(charger_src_str);
+  if (this->solar_power_priority_select_)
+    this->solar_power_priority_select_->map_and_publish(solar_prio_str);
+  if (this->input_voltage_range_select_)
+    this->input_voltage_range_select_->map_and_publish(input_v_range_str);
+  if (this->machine_type_select_)
+    this->machine_type_select_->map_and_publish(machine_type_str);
+  if (this->current_max_charging_current_select_)
+    this->current_max_charging_current_select_->map_and_publish(max_charging_i_str);
+  if (this->current_max_ac_charging_current_select_)
+    this->current_max_ac_charging_current_select_->map_and_publish(max_ac_charging_i_str);
+  if (this->battery_under_voltage_select_)
+    this->battery_under_voltage_select_->map_and_publish(bat_under_v_str);
+
+  if (this->output_source_priority_switch_)
+    this->output_source_priority_switch_->publish_state(out_src_priority != 0);
+  if (this->solar_power_priority_switch_)
+    this->solar_power_priority_switch_->publish_state(solar_priority == 1);
+  if (this->charger_source_priority_solarfirst_switch_)
+    this->charger_source_priority_solarfirst_switch_->publish_state(charger_src_priority == 2);
+  if (this->charger_source_priority_utility_switch_)
+    this->charger_source_priority_utility_switch_->publish_state(charger_src_priority == 0);
+  if (this->charger_source_priority_solaronly_switch_)
+    this->charger_source_priority_solaronly_switch_->publish_state(charger_src_priority == 3);
+}
+
+void Pipsolar::handle_p006mod_(const char *message) {
+  if (this->last_p006mod_) {
+    this->last_p006mod_->publish_state(message);
+  }
+  // ^D005<0><mode_char>  — mode digit is at index 6
+  if (strlen(message) < 7)
+    return;
+  const char mode_char = message[6];
+  const int mode_id = mode_char - '0';
+  if (this->device_mode_id_)
+    this->device_mode_id_->publish_state(mode_id);
+  if (this->device_mode_) {
+    const char *name;
+    switch (mode_char) {
+      case '1':
+        name = "Standby mode";
+        break;
+      case '2':
+        name = "Bypass mode";
+        break;
+      case '3':
+        name = "Battery mode";
+        break;
+      case '4':
+        name = "Fault mode";
+        break;
+      case '5':
+        name = "Hybrid mode";
+        break;
+      default:
+        name = nullptr;
+        break;
+    }
+    if (name)
+      this->device_mode_->publish_state(name);
+  }
+}
+
+void Pipsolar::handle_p007flag_(const char *message) {
+  if (this->last_p007flag_)
+    this->last_p007flag_->publish_state(message);
+  if (strlen(message) < 6)
+    return;
+
+  size_t pos = 0;
+  skip_start_(message, &pos);
+
+  binary_sensor::BinarySensor *flag_sensors[] = {
+      this->silence_buzzer_open_buzzer_,
+      this->overload_bypass_function_,
+      this->lcd_escape_to_default_,
+      this->overload_restart_function_,
+      this->over_temperature_restart_function_,
+      this->backlight_on_,
+      this->alarm_on_when_primary_source_interrupt_,
+      this->fault_code_record_,
+      this->power_saving_,
+  };
+  for (auto *sensor : flag_sensors)
+    this->publish_binary_sensor_(parse_number<int32_t>(read_field_(message, &pos)).value_or(0) != 0, sensor);
+}
+
+void Pipsolar::handle_p005fws_(const char *message) {
+  if (this->last_p005fws_)
+    this->last_p005fws_->publish_state(message);
+  if (strlen(message) < 6)
+    return;
+
+  size_t pos = 0;
+  skip_start_(message, &pos);
+
+  const int fault_code = parse_number<int32_t>(read_field_(message, &pos)).value_or(0);
+  if (this->fault_code_)
+    this->fault_code_->publish_state(fault_code);
+
+  binary_sensor::BinarySensor *warn_sensors[] = {
+      this->warning_line_fail_,
+      this->warning_output_circuit_short_,
+      this->warning_over_temperature_,
+      this->warning_fan_lock_,
+      this->warning_battery_voltage_high_,
+      this->warning_battery_low_alarm_,
+      this->warning_battery_under_shutdown_,
+      this->warning_over_load_,
+      this->warning_eeprom_failed_,
+      this->warning_power_limit_,
+      this->warning_pv1_voltage_high_,
+      this->warning_pv2_voltage_high_,
+      this->warning_mppt1_overload_,
+      this->warning_mppt2_overload_,
+      this->warning_scc1_battery_too_low_to_charge_,
+      this->warning_scc2_battery_too_low_to_charge_,
+  };
+  for (auto *sensor : warn_sensors)
+    this->publish_binary_sensor_(parse_number<int32_t>(read_field_(message, &pos)).value_or(0) != 0, sensor);
+}
+
+void Pipsolar::handle_p005et_(const char *message) {
+  if (this->last_p005et_)
+    this->last_p005et_->publish_state(message);
+  if (strlen(message) < 6)
+    return;
+  size_t pos = 0;
+  skip_start_(message, &pos);
+  read_sensor_(message, &pos, this->total_generated_energy_);
+}
+
+void Pipsolar::publish_mppt_status_(text_sensor::TextSensor *sensor, int value) {
+  if (!sensor)
+    return;
+  switch (value) {
+    case 0:
+      sensor->publish_state("abnormal");
+      break;
+    case 1:
+      sensor->publish_state("normal but not charging");
+      break;
+    case 2:
+      sensor->publish_state("charging");
+      break;
+    default:
+      break;
+  }
+}
+
+void Pipsolar::publish_direction_(text_sensor::TextSensor *sensor, int value) {
+  if (!sensor)
+    return;
+  switch (value) {
+    case 0:
+      sensor->publish_state("donothing");
+      break;
+    case 1:
+      sensor->publish_state("input");
+      break;
+    case 2:
+      sensor->publish_state("output");
+      break;
+    default:
+      break;
+  }
+}
+
+void Pipsolar::publish_binary_sensor_(esphome::optional<bool> b, binary_sensor::BinarySensor *sensor) {
+  if (sensor) {
+    if (b.has_value()) {
+      sensor->publish_state(b.value());
+    } else {
+      sensor->invalidate_state();
+    }
+  }
+}
+
+void Pipsolar::dump_config() {
+  ESP_LOGCONFIG(TAG, "PI18 enabled polling commands:");
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length != 0) {
+      ESP_LOGCONFIG(TAG, "%s", enabled_polling_command.command);
+    }
+  }
+}
+
+void Pipsolar::update() {
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length != 0) {
+      enabled_polling_command.needs_update = true;
+    }
+  }
+}
+
+void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand polling_command) {
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length == strlen(command)) {
+      uint8_t len = strlen(command);
+      if (memcmp(enabled_polling_command.command, command, len) == 0) {
+        return;
+      }
+    }
+    if (enabled_polling_command.length == 0) {
+      size_t length = strlen(command);
+      enabled_polling_command.command = new uint8_t[length + 1];  // NOLINT(cppcoreguidelines-owning-memory)
+      for (size_t i = 0; i < length + 1; i++) {
+        enabled_polling_command.command[i] = (uint8_t) command[i];
+      }
+      enabled_polling_command.errors = 0;
+      enabled_polling_command.identifier = polling_command;
+      enabled_polling_command.length = length;
+      enabled_polling_command.needs_update = true;
+      return;
+    }
+  }
+}
+
+uint16_t Pipsolar::pipsolar_crc_(uint8_t *msg, uint8_t len) {
+  uint16_t crc = crc16be(msg, len);
+  uint8_t crc_low = crc & 0xff;
+  uint8_t crc_high = crc >> 8;
+  if (crc_low == 0x28 || crc_low == 0x0d || crc_low == 0x0a)
+    crc_low++;
+  if (crc_high == 0x28 || crc_high == 0x0d || crc_high == 0x0a)
+    crc_high++;
+  crc = (crc_high << 8) | crc_low;
+  return crc;
+}
+
+void Pipsolar::handle_p007pgs0_(const char *message) {
+  size_t pos = 0;
+  skip_start_(message, &pos);
+
+  for (int i = 0; i < 9; i++)
+    skip_field_(message, &pos);
+
+  read_sensor_(message, &pos, this->total_ac_output_apparent_power_);
+  read_sensor_(message, &pos, this->total_ac_output_active_power_);
+  skip_field_(message, &pos);
+  read_sensor_(message, &pos, this->total_output_load_percent_);
+
+  for (int i = 0; i < 3; i++)
+    skip_field_(message, &pos);
+
+  read_sensor_(message, &pos, this->total_battery_charging_current_);
+}
+
+void Pipsolar::skip_start_(const char *message, size_t *pos) { *pos = 5; }
+
+void Pipsolar::skip_field_(const char *message, size_t *pos) {
+  while (message[*pos] != '\0' && message[*pos] != ',')
+    (*pos)++;
+  if (message[*pos] == ',')
+    (*pos)++;
+}
+
+std::string Pipsolar::read_field_(const char *message, size_t *pos) {
+  const size_t begin = *pos;
+  while (message[*pos] != '\0' && message[*pos] != ',')
+    (*pos)++;
+  std::string field(message, begin, *pos - begin);  // NOLINT
+  if (message[*pos] == ',')
+    (*pos)++;
+  return field;
+}
+
+void Pipsolar::read_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor, float scale) {
+  if (sensor != nullptr) {
+    auto val = parse_number<float>(read_field_(message, pos));
+    sensor->publish_state(val.has_value() ? val.value() * scale : NAN);
+  } else {
+    skip_field_(message, pos);
+  }
+}
+
+}  // namespace esphome::pi18

--- a/components/pi18/pipsolar.cpp
+++ b/components/pi18/pipsolar.cpp
@@ -676,7 +676,10 @@ void Pipsolar::handle_p007pgs0_(const char *message) {
   read_sensor_(message, &pos, this->total_battery_charging_current_);
 }
 
-void Pipsolar::skip_start_(const char *message, size_t *pos) { *pos = 5; }
+void Pipsolar::skip_start_(const char *message, size_t *pos) {
+  const size_t len = strlen(message);
+  *pos = (len >= 5) ? 5 : len;
+}
 
 void Pipsolar::skip_field_(const char *message, size_t *pos) {
   while (message[*pos] != '\0' && message[*pos] != ',')

--- a/components/pi18/pipsolar.h
+++ b/components/pi18/pipsolar.h
@@ -1,0 +1,265 @@
+#pragma once
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/select/select.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::pi18 {
+
+class PipsolarSelect;
+
+enum ENUMPollingCommand {
+  POLLING_P007PIRI = 0,
+  POLLING_P005GS = 1,
+  POLLING_P006MOD = 2,
+  POLLING_P007FLAG = 3,
+  POLLING_P005FWS = 4,
+  POLLING_P005ET = 5,
+  POLLING_P007PGS0 = 6,
+};
+
+struct PollingCommand {
+  uint8_t *command;
+  uint8_t length = 0;
+  uint8_t errors;
+  ENUMPollingCommand identifier;
+  bool needs_update;
+};
+
+struct QFLAGValues {
+  esphome::optional<bool> silence_buzzer_open_buzzer;
+  esphome::optional<bool> overload_bypass_function;
+  esphome::optional<bool> lcd_escape_to_default;
+  esphome::optional<bool> overload_restart_function;
+  esphome::optional<bool> over_temperature_restart_function;
+  esphome::optional<bool> backlight_on;
+  esphome::optional<bool> alarm_on_when_primary_source_interrupt;
+  esphome::optional<bool> fault_code_record;
+  esphome::optional<bool> power_saving;
+};
+
+// Poll commands are sent as "^" + polling_command_name + CRC + CR
+#define PIPSOLAR_ENTITY_(type, name, polling_command) \
+ protected: \
+  type *name##_{}; /* NOLINT */ \
+\
+ public: \
+  void set_##name(type *name) { /* NOLINT */ \
+    this->name##_ = name; \
+    this->add_polling_command_("^" #polling_command, POLLING_##polling_command); \
+  }
+
+#define PIPSOLAR_SENSOR(name, polling_command) PIPSOLAR_ENTITY_(sensor::Sensor, name, polling_command)
+#define PIPSOLAR_SWITCH(name, polling_command) PIPSOLAR_ENTITY_(switch_::Switch, name, polling_command)
+#define PIPSOLAR_BINARY_SENSOR(name, polling_command) \
+  PIPSOLAR_ENTITY_(binary_sensor::BinarySensor, name, polling_command)
+#define PIPSOLAR_TEXT_SENSOR(name, polling_command) PIPSOLAR_ENTITY_(text_sensor::TextSensor, name, polling_command)
+#define PIPSOLAR_SELECT(name, polling_command) PIPSOLAR_ENTITY_(PipsolarSelect, name, polling_command)
+
+class Pipsolar : public uart::UARTDevice, public PollingComponent {
+  // ^P005GS — general status (28 comma-separated fields)
+  PIPSOLAR_SENSOR(grid_voltage, P005GS)
+  PIPSOLAR_SENSOR(grid_frequency, P005GS)
+  PIPSOLAR_SENSOR(ac_output_voltage, P005GS)
+  PIPSOLAR_SENSOR(ac_output_frequency, P005GS)
+  PIPSOLAR_SENSOR(ac_output_apparent_power, P005GS)
+  PIPSOLAR_SENSOR(ac_output_active_power, P005GS)
+  PIPSOLAR_SENSOR(output_load_percent, P005GS)
+  PIPSOLAR_SENSOR(battery_voltage, P005GS)
+  PIPSOLAR_SENSOR(battery_voltage_scc, P005GS)
+  PIPSOLAR_SENSOR(battery_voltage_scc2, P005GS)
+  PIPSOLAR_SENSOR(battery_discharge_current, P005GS)
+  PIPSOLAR_SENSOR(battery_charging_current, P005GS)
+  PIPSOLAR_SENSOR(battery_capacity_percent, P005GS)
+  PIPSOLAR_SENSOR(inverter_heat_sink_temperature, P005GS)
+  PIPSOLAR_SENSOR(mppt1_charger_temperature, P005GS)
+  PIPSOLAR_SENSOR(mppt2_charger_temperature, P005GS)
+  PIPSOLAR_SENSOR(pv1_input_power, P005GS)
+  PIPSOLAR_SENSOR(pv2_input_power, P005GS)
+  PIPSOLAR_SENSOR(pv1_input_voltage, P005GS)
+  PIPSOLAR_SENSOR(pv2_input_voltage, P005GS)
+  PIPSOLAR_BINARY_SENSOR(setting_value_configuration_state, P005GS)
+  PIPSOLAR_TEXT_SENSOR(mppt1_charger_status, P005GS)
+  PIPSOLAR_TEXT_SENSOR(mppt2_charger_status, P005GS)
+  PIPSOLAR_TEXT_SENSOR(load_connection, P005GS)
+  PIPSOLAR_TEXT_SENSOR(battery_power_direction, P005GS)
+  PIPSOLAR_TEXT_SENSOR(dc_ac_power_direction, P005GS)
+  PIPSOLAR_TEXT_SENSOR(line_power_direction, P005GS)
+
+  // ^P007PIRI — device ratings (25 fields, ×0.1 for voltages/currents/frequencies)
+  PIPSOLAR_SENSOR(grid_rating_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(grid_rating_current, P007PIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_frequency, P007PIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_current, P007PIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_apparent_power, P007PIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_active_power, P007PIRI)
+  PIPSOLAR_SENSOR(battery_rating_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(battery_recharge_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(battery_redischarge_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(battery_under_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(battery_bulk_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(battery_float_voltage, P007PIRI)
+  PIPSOLAR_SENSOR(battery_type, P007PIRI)
+  PIPSOLAR_SENSOR(current_max_ac_charging_current, P007PIRI)
+  PIPSOLAR_SENSOR(current_max_charging_current, P007PIRI)
+  PIPSOLAR_SENSOR(input_voltage_range, P007PIRI)
+  PIPSOLAR_SENSOR(output_source_priority, P007PIRI)
+  PIPSOLAR_SENSOR(charger_source_priority, P007PIRI)
+  PIPSOLAR_SENSOR(parallel_max_num, P007PIRI)
+  PIPSOLAR_SENSOR(machine_type, P007PIRI)
+  PIPSOLAR_SENSOR(topology, P007PIRI)
+  PIPSOLAR_SENSOR(output_mode, P007PIRI)
+  PIPSOLAR_SENSOR(solar_power_priority, P007PIRI)
+  PIPSOLAR_SENSOR(mppt_string, P007PIRI)
+
+  // ^P006MOD — device mode
+  PIPSOLAR_TEXT_SENSOR(device_mode, P006MOD)
+  PIPSOLAR_SENSOR(device_mode_id, P006MOD)
+
+  // ^P007FLAG — 9 enable/disable flags
+  PIPSOLAR_BINARY_SENSOR(silence_buzzer_open_buzzer, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(overload_bypass_function, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(lcd_escape_to_default, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(overload_restart_function, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(over_temperature_restart_function, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(backlight_on, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(alarm_on_when_primary_source_interrupt, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(fault_code_record, P007FLAG)
+  PIPSOLAR_BINARY_SENSOR(power_saving, P007FLAG)
+
+  // ^P005FWS — fault/warning status
+  PIPSOLAR_SENSOR(fault_code, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_line_fail, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_output_circuit_short, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_over_temperature, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_fan_lock, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_voltage_high, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_low_alarm, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_under_shutdown, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_over_load, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_eeprom_failed, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_power_limit, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_pv1_voltage_high, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_pv2_voltage_high, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_mppt1_overload, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_mppt2_overload, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_scc1_battery_too_low_to_charge, P005FWS)
+  PIPSOLAR_BINARY_SENSOR(warning_scc2_battery_too_low_to_charge, P005FWS)
+
+  // ^P005ET — total generated energy (8-digit, kWh)
+  PIPSOLAR_SENSOR(total_generated_energy, P005ET)
+
+  // ^P007PGS0 — parallel unit aggregate status
+  PIPSOLAR_SENSOR(total_ac_output_apparent_power, P007PGS0)
+  PIPSOLAR_SENSOR(total_ac_output_active_power, P007PGS0)
+  PIPSOLAR_SENSOR(total_output_load_percent, P007PGS0)
+  PIPSOLAR_SENSOR(total_battery_charging_current, P007PGS0)
+
+  // Raw response text sensors (one per command)
+  PIPSOLAR_TEXT_SENSOR(last_p005gs, P005GS)
+  PIPSOLAR_TEXT_SENSOR(last_p007piri, P007PIRI)
+  PIPSOLAR_TEXT_SENSOR(last_p006mod, P006MOD)
+  PIPSOLAR_TEXT_SENSOR(last_p007flag, P007FLAG)
+  PIPSOLAR_TEXT_SENSOR(last_p005fws, P005FWS)
+  PIPSOLAR_TEXT_SENSOR(last_p005et, P005ET)
+
+  // Selects — user defines optionsmap/statusmap in YAML with ^S commands
+  PIPSOLAR_SELECT(output_source_priority_select, P007PIRI)
+  PIPSOLAR_SELECT(charger_source_priority_select, P007PIRI)
+  PIPSOLAR_SELECT(solar_power_priority_select, P007PIRI)
+  PIPSOLAR_SELECT(input_voltage_range_select, P007PIRI)
+  PIPSOLAR_SELECT(machine_type_select, P007PIRI)
+  PIPSOLAR_SELECT(current_max_charging_current_select, P007PIRI)
+  PIPSOLAR_SELECT(current_max_ac_charging_current_select, P007PIRI)
+  PIPSOLAR_SELECT(battery_under_voltage_select, P007PIRI)
+
+  // Switches — on/off commands are full ^S<len><cmd> strings
+  PIPSOLAR_SWITCH(output_source_priority_switch, P007PIRI)
+  PIPSOLAR_SWITCH(solar_power_priority_switch, P007PIRI)
+  PIPSOLAR_SWITCH(charger_source_priority_solarfirst_switch, P007PIRI)
+  PIPSOLAR_SWITCH(charger_source_priority_utility_switch, P007PIRI)
+  PIPSOLAR_SWITCH(charger_source_priority_solaronly_switch, P007PIRI)
+  PIPSOLAR_SWITCH(silence_buzzer_open_buzzer_switch, P007FLAG)
+  PIPSOLAR_SWITCH(overload_bypass_function_switch, P007FLAG)
+  PIPSOLAR_SWITCH(lcd_escape_to_default_switch, P007FLAG)
+  PIPSOLAR_SWITCH(overload_restart_function_switch, P007FLAG)
+  PIPSOLAR_SWITCH(over_temperature_restart_function_switch, P007FLAG)
+  PIPSOLAR_SWITCH(backlight_on_switch, P007FLAG)
+  PIPSOLAR_SWITCH(alarm_on_when_primary_source_interrupt_switch, P007FLAG)
+  PIPSOLAR_SWITCH(fault_code_record_switch, P007FLAG)
+  PIPSOLAR_SWITCH(power_saving_switch, P007FLAG)
+
+  void queue_command(const std::string &command);
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  void update() override;
+
+ protected:
+  static const size_t PIPSOLAR_READ_BUFFER_LENGTH = 200;
+  static const size_t COMMAND_QUEUE_LENGTH = 10;
+  static const size_t COMMAND_TIMEOUT = 5000;
+  static const size_t POLLING_COMMANDS_MAX = 10;
+
+  void add_polling_command_(const char *command, ENUMPollingCommand polling_command);
+  void empty_uart_buffer_();
+  uint8_t check_incoming_crc_();
+  uint8_t check_incoming_length_(uint8_t length);
+  uint16_t pipsolar_crc_(uint8_t *msg, uint8_t len);
+  bool send_next_command_();
+  bool send_next_poll_();
+
+  void handle_poll_response_(ENUMPollingCommand polling_command, const char *message);
+  void handle_poll_error_(ENUMPollingCommand polling_command);
+  void handle_p005gs_(const char *message);
+  void handle_p007piri_(const char *message);
+  void handle_p006mod_(const char *message);
+  void handle_p007flag_(const char *message);
+  void handle_p005fws_(const char *message);
+  void handle_p005et_(const char *message);
+  void handle_p007pgs0_(const char *message);
+
+  void publish_mppt_status_(text_sensor::TextSensor *sensor, int value);
+  void publish_direction_(text_sensor::TextSensor *sensor, int value);
+  void publish_binary_sensor_(esphome::optional<bool> b, binary_sensor::BinarySensor *sensor);
+
+  void skip_start_(const char *message, size_t *pos);
+  void skip_field_(const char *message, size_t *pos);
+  std::string read_field_(const char *message, size_t *pos);
+  void read_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor, float scale = 1.0f);
+
+  std::string command_queue_[COMMAND_QUEUE_LENGTH];
+  uint8_t command_queue_position_ = 0;
+  uint8_t read_buffer_[PIPSOLAR_READ_BUFFER_LENGTH];
+  size_t read_pos_{0};
+
+  uint32_t command_start_millis_ = 0;
+  uint8_t state_;
+  enum State {
+    STATE_IDLE = 0,
+    STATE_POLL = 1,
+    STATE_COMMAND = 2,
+    STATE_POLL_COMPLETE = 3,
+    STATE_COMMAND_COMPLETE = 4,
+    STATE_POLL_CHECKED = 5,
+  };
+
+  uint8_t last_polling_command_ = 0;
+  PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
+};
+
+}  // namespace esphome::pi18
+
+#undef PIPSOLAR_ENTITY_
+#undef PIPSOLAR_SENSOR
+#undef PIPSOLAR_SWITCH
+#undef PIPSOLAR_BINARY_SENSOR
+#undef PIPSOLAR_TEXT_SENSOR
+#undef PIPSOLAR_SELECT

--- a/components/pi18/pipsolar_select.cpp
+++ b/components/pi18/pipsolar_select.cpp
@@ -1,0 +1,33 @@
+#include "pipsolar_select.h"
+#include "esphome/core/log.h"
+
+namespace esphome::pi18 {
+
+static const char *const TAG = "pi18.select";
+
+void PipsolarSelect::dump_config() { LOG_SELECT(TAG, "PI18 Controller Select", this); }
+
+void PipsolarSelect::control(const std::string &value) {
+  ESP_LOGD(TAG, "got option: %s", value.c_str());
+  if (this->mapping_.contains(value)) {
+    ESP_LOGD(TAG, "found mapped option %s for option %s", this->mapping_[value].c_str(), value.c_str());
+    this->parent_->queue_command(this->mapping_[value]);
+  } else {
+    ESP_LOGD(TAG, "could not find option %s in mapping", value.c_str());
+    return;
+  }
+  if (this->optimistic_)
+    this->publish_state(value);
+}
+
+void PipsolarSelect::map_and_publish(std::string &value) {
+  ESP_LOGD(TAG, "got value: %s", value.c_str());
+  if (this->status_mapping_.contains(value)) {
+    ESP_LOGD(TAG, "found mapped option %s for option %s", this->status_mapping_[value].c_str(), value.c_str());
+    this->publish_state(this->status_mapping_[value]);
+  } else {
+    ESP_LOGD(TAG, "could not find option %s in mapping", value.c_str());
+  }
+}
+
+}  // namespace esphome::pi18

--- a/components/pi18/pipsolar_select.h
+++ b/components/pi18/pipsolar_select.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <map>
+#include <utility>
+
+#include "esphome/components/pi18/pipsolar.h"
+#include "esphome/components/select/select.h"
+#include "esphome/core/component.h"
+
+namespace esphome::pi18 {
+class Pipsolar;
+
+class PipsolarSelect : public Component, public select::Select {
+ public:
+  void set_parent(Pipsolar *const parent) { this->parent_ = parent; }
+  void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
+  void add_mapping(const std::string &key, std::string value) { this->mapping_[key] = std::move(value); }
+  void add_status_mapping(const std::string &key, std::string value) { this->status_mapping_[key] = std::move(value); }
+  void dump_config() override;
+  void control(const std::string &value) override;
+  void map_and_publish(std::string &value);
+
+ protected:
+  std::map<std::string, std::string> mapping_;
+  std::map<std::string, std::string> status_mapping_;
+  Pipsolar *parent_;
+  bool optimistic_{false};
+};
+
+}  // namespace esphome::pi18

--- a/components/pi18/select/__init__.py
+++ b/components/pi18/select/__init__.py
@@ -1,0 +1,81 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA, pipsolar_ns
+
+DEPENDENCIES = ["uart"]
+
+CONF_OPTIONSMAP = "optionsmap"
+CONF_STATUSMAP = "statusmap"
+
+CONF_OUTPUT_SOURCE_PRIORITY = "output_source_priority"
+CONF_CHARGER_SOURCE_PRIORITY = "charger_source_priority"
+CONF_SOLAR_POWER_PRIORITY = "solar_power_priority"
+CONF_INPUT_VOLTAGE_RANGE = "input_voltage_range"
+CONF_MACHINE_TYPE = "machine_type"
+CONF_CURRENT_MAX_CHARGING_CURRENT = "current_max_charging_current"
+CONF_CURRENT_MAX_AC_CHARGING_CURRENT = "current_max_ac_charging_current"
+CONF_BATTERY_UNDER_VOLTAGE = "battery_under_voltage"
+
+PipsolarSelect = pipsolar_ns.class_("PipsolarSelect", cg.Component, select.Select)
+
+
+def ensure_option_map():
+    def validator(value):
+        cv.check_not_templatable(value)
+        options_map_schema = cv.Schema(
+            {cv.All(cv.string_strict): cv.All(cv.string_strict)}
+        )
+        value = options_map_schema(value)
+        all_values = list(value.values())
+        if len(all_values) != len(set(all_values)):
+            raise cv.Invalid("Mapping values must be unique.")
+        return value
+
+    return validator
+
+
+TYPES = [
+    CONF_OUTPUT_SOURCE_PRIORITY,
+    CONF_CHARGER_SOURCE_PRIORITY,
+    CONF_SOLAR_POWER_PRIORITY,
+    CONF_INPUT_VOLTAGE_RANGE,
+    CONF_MACHINE_TYPE,
+    CONF_CURRENT_MAX_CHARGING_CURRENT,
+    CONF_CURRENT_MAX_AC_CHARGING_CURRENT,
+    CONF_BATTERY_UNDER_VOLTAGE,
+]
+
+PIPSELECT_SCHEMA = cv.COMPONENT_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(PipsolarSelect),
+        cv.Optional(CONF_OPTIONSMAP): ensure_option_map(),
+        cv.Optional(CONF_STATUSMAP): ensure_option_map(),
+    }
+).extend(select.select_schema(PipsolarSelect))
+
+CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
+    {cv.Optional(type): PIPSELECT_SCHEMA for type in TYPES}
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
+
+    for type in TYPES:
+        if type in config:
+            conf = config[type]
+            options_map = conf[CONF_OPTIONSMAP]
+            var = cg.new_Pvariable(conf[CONF_ID])
+            await cg.register_component(var, conf)
+            await select.register_select(var, conf, options=list(options_map.keys()))
+            cg.add(getattr(paren, f"set_{type}_select")(var))
+            cg.add(var.set_parent(paren))
+            for mappingkey in options_map:
+                cg.add(var.add_mapping(mappingkey, options_map[mappingkey]))
+            if CONF_STATUSMAP in conf:
+                status_map = conf[CONF_STATUSMAP]
+                for mappingkey in status_map:
+                    cg.add(var.add_status_mapping(mappingkey, status_map[mappingkey]))

--- a/components/pi18/sensor/__init__.py
+++ b/components/pi18/sensor/__init__.py
@@ -1,0 +1,378 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_BATTERY_VOLTAGE,
+    DEVICE_CLASS_APPARENT_POWER,
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_FREQUENCY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
+    ICON_BATTERY,
+    ICON_CURRENT_AC,
+    ICON_GAUGE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_HERTZ,
+    UNIT_KILOWATT_HOURS,
+    UNIT_PERCENT,
+    UNIT_VOLT,
+    UNIT_VOLT_AMPS,
+    UNIT_WATT,
+)
+
+from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["uart"]
+
+ICON_CURRENT_DC = "mdi:current-dc"
+ICON_SOLAR_PANEL = "mdi:solar-panel"
+ICON_SOLAR_POWER = "mdi:solar-power"
+
+# P005GS sensors
+CONF_GRID_VOLTAGE = "grid_voltage"
+CONF_GRID_FREQUENCY = "grid_frequency"
+CONF_AC_OUTPUT_VOLTAGE = "ac_output_voltage"
+CONF_AC_OUTPUT_FREQUENCY = "ac_output_frequency"
+CONF_AC_OUTPUT_APPARENT_POWER = "ac_output_apparent_power"
+CONF_AC_OUTPUT_ACTIVE_POWER = "ac_output_active_power"
+CONF_OUTPUT_LOAD_PERCENT = "output_load_percent"
+CONF_BATTERY_VOLTAGE_SCC = "battery_voltage_scc"
+CONF_BATTERY_VOLTAGE_SCC2 = "battery_voltage_scc2"
+CONF_BATTERY_DISCHARGE_CURRENT = "battery_discharge_current"
+CONF_BATTERY_CHARGING_CURRENT = "battery_charging_current"
+CONF_BATTERY_CAPACITY_PERCENT = "battery_capacity_percent"
+CONF_INVERTER_HEAT_SINK_TEMPERATURE = "inverter_heat_sink_temperature"
+CONF_MPPT1_CHARGER_TEMPERATURE = "mppt1_charger_temperature"
+CONF_MPPT2_CHARGER_TEMPERATURE = "mppt2_charger_temperature"
+CONF_PV1_INPUT_POWER = "pv1_input_power"
+CONF_PV2_INPUT_POWER = "pv2_input_power"
+CONF_PV1_INPUT_VOLTAGE = "pv1_input_voltage"
+CONF_PV2_INPUT_VOLTAGE = "pv2_input_voltage"
+
+# P007PIRI sensors
+CONF_GRID_RATING_VOLTAGE = "grid_rating_voltage"
+CONF_GRID_RATING_CURRENT = "grid_rating_current"
+CONF_AC_OUTPUT_RATING_VOLTAGE = "ac_output_rating_voltage"
+CONF_AC_OUTPUT_RATING_FREQUENCY = "ac_output_rating_frequency"
+CONF_AC_OUTPUT_RATING_CURRENT = "ac_output_rating_current"
+CONF_AC_OUTPUT_RATING_APPARENT_POWER = "ac_output_rating_apparent_power"
+CONF_AC_OUTPUT_RATING_ACTIVE_POWER = "ac_output_rating_active_power"
+CONF_BATTERY_RATING_VOLTAGE = "battery_rating_voltage"
+CONF_BATTERY_RECHARGE_VOLTAGE = "battery_recharge_voltage"
+CONF_BATTERY_REDISCHARGE_VOLTAGE = "battery_redischarge_voltage"
+CONF_BATTERY_UNDER_VOLTAGE = "battery_under_voltage"
+CONF_BATTERY_BULK_VOLTAGE = "battery_bulk_voltage"
+CONF_BATTERY_FLOAT_VOLTAGE = "battery_float_voltage"
+CONF_BATTERY_TYPE = "battery_type"
+CONF_CURRENT_MAX_AC_CHARGING_CURRENT = "current_max_ac_charging_current"
+CONF_CURRENT_MAX_CHARGING_CURRENT = "current_max_charging_current"
+CONF_INPUT_VOLTAGE_RANGE = "input_voltage_range"
+CONF_OUTPUT_SOURCE_PRIORITY = "output_source_priority"
+CONF_CHARGER_SOURCE_PRIORITY = "charger_source_priority"
+CONF_PARALLEL_MAX_NUM = "parallel_max_num"
+CONF_MACHINE_TYPE = "machine_type"
+CONF_TOPOLOGY = "topology"
+CONF_OUTPUT_MODE = "output_mode"
+CONF_SOLAR_POWER_PRIORITY = "solar_power_priority"
+CONF_MPPT_STRING = "mppt_string"
+
+# P007PGS0 sensors
+CONF_TOTAL_AC_OUTPUT_APPARENT_POWER = "total_ac_output_apparent_power"
+CONF_TOTAL_AC_OUTPUT_ACTIVE_POWER = "total_ac_output_active_power"
+CONF_TOTAL_OUTPUT_LOAD_PERCENT = "total_output_load_percent"
+CONF_TOTAL_BATTERY_CHARGING_CURRENT = "total_battery_charging_current"
+
+# P006MOD sensor
+CONF_DEVICE_MODE_ID = "device_mode_id"
+
+# P005ET sensor
+CONF_TOTAL_GENERATED_ENERGY = "total_generated_energy"
+
+# P005FWS sensor
+CONF_FAULT_CODE = "fault_code"
+
+TYPES = {
+    CONF_GRID_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_GRID_FREQUENCY: sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        icon=ICON_CURRENT_AC,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_FREQUENCY: sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        icon=ICON_CURRENT_AC,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_APPARENT_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT_AMPS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_APPARENT_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_ACTIVE_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_WATT,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_OUTPUT_LOAD_PERCENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        icon=ICON_GAUGE,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        icon=ICON_BATTERY,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_VOLTAGE_SCC: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_VOLTAGE_SCC2: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_DISCHARGE_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        icon=ICON_CURRENT_DC,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_CHARGING_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        icon=ICON_CURRENT_DC,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_CAPACITY_PERCENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_BATTERY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_INVERTER_HEAT_SINK_TEMPERATURE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_MPPT1_CHARGER_TEMPERATURE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_MPPT2_CHARGER_TEMPERATURE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_PV1_INPUT_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_WATT,
+        icon=ICON_SOLAR_POWER,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_PV2_INPUT_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_WATT,
+        icon=ICON_SOLAR_POWER,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_PV1_INPUT_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        icon=ICON_SOLAR_PANEL,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_PV2_INPUT_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        icon=ICON_SOLAR_PANEL,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_GRID_RATING_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_GRID_RATING_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_RATING_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_RATING_FREQUENCY: sensor.sensor_schema(
+        unit_of_measurement=UNIT_HERTZ,
+        icon=ICON_CURRENT_AC,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_RATING_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_RATING_APPARENT_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT_AMPS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_APPARENT_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_AC_OUTPUT_RATING_ACTIVE_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_WATT,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_RATING_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_RECHARGE_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_REDISCHARGE_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_UNDER_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_BULK_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_FLOAT_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_BATTERY_TYPE: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_CURRENT_MAX_AC_CHARGING_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_CURRENT_MAX_CHARGING_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_INPUT_VOLTAGE_RANGE: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_OUTPUT_SOURCE_PRIORITY: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_CHARGER_SOURCE_PRIORITY: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_PARALLEL_MAX_NUM: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_MACHINE_TYPE: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_TOPOLOGY: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_OUTPUT_MODE: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_SOLAR_POWER_PRIORITY: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_MPPT_STRING: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_TOTAL_GENERATED_ENERGY: sensor.sensor_schema(
+        unit_of_measurement=UNIT_KILOWATT_HOURS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+    ),
+    CONF_FAULT_CODE: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_DEVICE_MODE_ID: sensor.sensor_schema(accuracy_decimals=0),
+    CONF_TOTAL_AC_OUTPUT_APPARENT_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT_AMPS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_APPARENT_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_TOTAL_AC_OUTPUT_ACTIVE_POWER: sensor.sensor_schema(
+        unit_of_measurement=UNIT_WATT,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_TOTAL_OUTPUT_LOAD_PERCENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        icon=ICON_GAUGE,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_TOTAL_BATTERY_CHARGING_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        icon=ICON_CURRENT_DC,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+}
+
+CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
+    {cv.Optional(type): schema for type, schema in TYPES.items()}
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
+
+    for type in TYPES:
+        if type in config:
+            conf = config[type]
+            sens = await sensor.new_sensor(conf)
+            cg.add(getattr(paren, f"set_{type}")(sens))

--- a/components/pi18/switch/__init__.py
+++ b/components/pi18/switch/__init__.py
@@ -1,0 +1,65 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import ICON_POWER
+
+from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA, pipsolar_ns
+
+DEPENDENCIES = ["uart"]
+
+CONF_OUTPUT_SOURCE_PRIORITY = "output_source_priority"
+CONF_SOLAR_POWER_PRIORITY = "solar_power_priority"
+CONF_CHARGER_SOURCE_PRIORITY_SOLARFIRST = "charger_source_priority_solarfirst"
+CONF_CHARGER_SOURCE_PRIORITY_UTILITY = "charger_source_priority_utility"
+CONF_CHARGER_SOURCE_PRIORITY_SOLARONLY = "charger_source_priority_solaronly"
+CONF_SILENCE_BUZZER_OPEN_BUZZER = "silence_buzzer_open_buzzer"
+CONF_OVERLOAD_BYPASS_FUNCTION = "overload_bypass_function"
+CONF_LCD_ESCAPE_TO_DEFAULT = "lcd_escape_to_default"
+CONF_OVERLOAD_RESTART_FUNCTION = "overload_restart_function"
+CONF_OVER_TEMPERATURE_RESTART_FUNCTION = "over_temperature_restart_function"
+CONF_BACKLIGHT_ON = "backlight_on"
+CONF_ALARM_ON_WHEN_PRIMARY_SOURCE_INTERRUPT = "alarm_on_when_primary_source_interrupt"
+CONF_FAULT_CODE_RECORD = "fault_code_record"
+CONF_POWER_SAVING = "power_saving"
+
+TYPES = {
+    CONF_OUTPUT_SOURCE_PRIORITY: ("^S007POP1", "^S007POP0"),
+    CONF_SOLAR_POWER_PRIORITY: ("^S007PSP1", "^S007PSP0"),
+    CONF_CHARGER_SOURCE_PRIORITY_SOLARFIRST: ("^S009PCP0,0", None),
+    CONF_CHARGER_SOURCE_PRIORITY_UTILITY: ("^S009PCP0,1", None),
+    CONF_CHARGER_SOURCE_PRIORITY_SOLARONLY: ("^S009PCP0,2", None),
+    CONF_SILENCE_BUZZER_OPEN_BUZZER: ("^S006PEA", "^S006PDA"),
+    CONF_OVERLOAD_BYPASS_FUNCTION: ("^S006PEB", "^S006PDB"),
+    CONF_LCD_ESCAPE_TO_DEFAULT: ("^S006PEC", "^S006PDC"),
+    CONF_OVERLOAD_RESTART_FUNCTION: ("^S006PED", "^S006PDD"),
+    CONF_OVER_TEMPERATURE_RESTART_FUNCTION: ("^S006PEE", "^S006PDE"),
+    CONF_BACKLIGHT_ON: ("^S006PEF", "^S006PDF"),
+    CONF_ALARM_ON_WHEN_PRIMARY_SOURCE_INTERRUPT: ("^S006PEG", "^S006PDG"),
+    CONF_FAULT_CODE_RECORD: ("^S006PEH", "^S006PDH"),
+    CONF_POWER_SAVING: ("^S006PEI", "^S006PDI"),
+}
+
+PipsolarSwitch = pipsolar_ns.class_("PipsolarSwitch", switch.Switch, cg.Component)
+
+PIPSWITCH_SCHEMA = switch.switch_schema(
+    PipsolarSwitch, icon=ICON_POWER, block_inverted=True
+).extend(cv.COMPONENT_SCHEMA)
+
+CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
+    {cv.Optional(type): PIPSWITCH_SCHEMA for type in TYPES}
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
+
+    for type, (on, off) in TYPES.items():
+        if type in config:
+            conf = config[type]
+            var = await switch.new_switch(conf)
+            await cg.register_component(var, conf)
+            cg.add(getattr(paren, f"set_{type}_switch")(var))
+            cg.add(var.set_parent(paren))
+            cg.add(var.set_on_command(on))
+            if off is not None:
+                cg.add(var.set_off_command(off))

--- a/components/pi18/switch/pipsolar_switch.cpp
+++ b/components/pi18/switch/pipsolar_switch.cpp
@@ -1,0 +1,16 @@
+#include "pipsolar_switch.h"
+#include "esphome/core/log.h"
+
+namespace esphome::pi18 {
+
+static const char *const TAG = "pi18.switch";
+
+void PipsolarSwitch::dump_config() { LOG_SWITCH("", "PI18 Switch", this); }
+void PipsolarSwitch::write_state(bool state) {
+  const char *command = state ? this->on_command_ : this->off_command_;
+  if (command != nullptr) {
+    this->parent_->queue_command(command);
+  }
+}
+
+}  // namespace esphome::pi18

--- a/components/pi18/switch/pipsolar_switch.h
+++ b/components/pi18/switch/pipsolar_switch.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../pipsolar.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/component.h"
+
+namespace esphome::pi18 {
+class Pipsolar;
+class PipsolarSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(Pipsolar *parent) { this->parent_ = parent; }
+  void set_on_command(const char *command) { this->on_command_ = command; }
+  void set_off_command(const char *command) { this->off_command_ = command; }
+  void set_on_command(const std::string &command) = delete;
+  void set_off_command(const std::string &command) = delete;
+  void dump_config() override;
+
+ protected:
+  void write_state(bool state) override;
+  const char *on_command_{nullptr};
+  const char *off_command_{nullptr};
+  Pipsolar *parent_;
+};
+
+}  // namespace esphome::pi18

--- a/components/pi18/text_sensor/__init__.py
+++ b/components/pi18/text_sensor/__init__.py
@@ -1,0 +1,56 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+
+from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["uart"]
+
+# P005GS text sensors
+CONF_MPPT1_CHARGER_STATUS = "mppt1_charger_status"
+CONF_MPPT2_CHARGER_STATUS = "mppt2_charger_status"
+CONF_LOAD_CONNECTION = "load_connection"
+CONF_BATTERY_POWER_DIRECTION = "battery_power_direction"
+CONF_DC_AC_POWER_DIRECTION = "dc_ac_power_direction"
+CONF_LINE_POWER_DIRECTION = "line_power_direction"
+
+# P006MOD text sensor
+CONF_DEVICE_MODE = "device_mode"
+
+# Raw response text sensors
+CONF_LAST_P005GS = "last_p005gs"
+CONF_LAST_P007PIRI = "last_p007piri"
+CONF_LAST_P006MOD = "last_p006mod"
+CONF_LAST_P007FLAG = "last_p007flag"
+CONF_LAST_P005FWS = "last_p005fws"
+CONF_LAST_P005ET = "last_p005et"
+
+TYPES = [
+    CONF_MPPT1_CHARGER_STATUS,
+    CONF_MPPT2_CHARGER_STATUS,
+    CONF_LOAD_CONNECTION,
+    CONF_BATTERY_POWER_DIRECTION,
+    CONF_DC_AC_POWER_DIRECTION,
+    CONF_LINE_POWER_DIRECTION,
+    CONF_DEVICE_MODE,
+    CONF_LAST_P005GS,
+    CONF_LAST_P007PIRI,
+    CONF_LAST_P006MOD,
+    CONF_LAST_P007FLAG,
+    CONF_LAST_P005FWS,
+    CONF_LAST_P005ET,
+]
+
+CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
+    {cv.Optional(type): text_sensor.text_sensor_schema() for type in TYPES}
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
+
+    for type in TYPES:
+        if type in config:
+            conf = config[type]
+            var = await text_sensor.new_text_sensor(conf)
+            cg.add(getattr(paren, f"set_{type}")(var))

--- a/components/pip2424mse1/pipsolar.h
+++ b/components/pip2424mse1/pipsolar.h
@@ -262,3 +262,10 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
 };
 
 }  // namespace esphome::pip2424mse1
+
+#undef PIPSOLAR_ENTITY_
+#undef PIPSOLAR_SENSOR
+#undef PIPSOLAR_SWITCH
+#undef PIPSOLAR_BINARY_SENSOR
+#undef PIPSOLAR_TEXT_SENSOR
+#undef PIPSOLAR_SELECT

--- a/components/pip8048/pipsolar.h
+++ b/components/pip8048/pipsolar.h
@@ -272,3 +272,10 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
 };
 
 }  // namespace esphome::pip8048
+
+#undef PIPSOLAR_ENTITY_
+#undef PIPSOLAR_SENSOR
+#undef PIPSOLAR_SWITCH
+#undef PIPSOLAR_BINARY_SENSOR
+#undef PIPSOLAR_TEXT_SENSOR
+#undef PIPSOLAR_SELECT

--- a/docs/pdus/pi18/lv5048.txt
+++ b/docs/pdus/pi18/lv5048.txt
@@ -1,0 +1,140 @@
+# Traffic pi18, MppSolar LV5048 Hybrid V2 / compatible PI18 inverters
+# Source: https://github.com/syssi/esphome-pipsolar/issues/54
+#
+# PI18 protocol: queries use ^P<len><cmd> + CRC16 + CR (0x0D)
+#                responses use ^D<len><data> + CRC16 + CR (0x0D)
+#                set commands use ^S<len><cmd> + CRC16 + CR (0x0D)
+#                ACK/NAK responses use (ACK or (NAK + CRC16 + CR (0x0D)
+#
+# Contributed by BanannaJoe and BeckoPopov via GitHub issue #54
+# BanannaJoe's inverter: LV5048 Hybrid V2, 5600W, 48V system
+# BeckoPopov's inverter: LV5048 compatible, 5600W, 48V system
+
+# --- ^P005GS (General Status, 28 comma-separated fields) ---
+#
+# Field mapping (sscanf "^D%3d%f,%f,%f,%f,%d,%d,%d,%f,%f,%f,%d,%d,%d,%d,%f, %f,%f,%f,%f,%f,%d,%d,%d,%d,%d,%d,%d,%d"):
+#  1: grid_voltage          ×0.1 V
+#  2: grid_frequency        ×0.1 Hz
+#  3: ac_output_voltage     ×0.1 V
+#  4: ac_output_frequency   ×0.1 Hz
+#  5: ac_output_apparent_power  VA
+#  6: ac_output_active_power    W
+#  7: output_load_percent       %
+#  8: battery_voltage       ×0.1 V
+#  9: battery_voltage_scc   ×0.1 V
+# 10: battery_voltage_scc2  ×0.1 V
+# 11: battery_discharge_current  A (×−1 when publishing)
+# 12: battery_charging_current   A
+# 13: battery_capacity_percent   %
+# 14: inverter_heat_sink_temperature  °C
+# 15: mppt1_charger_temperature  °C (no ×0.1)
+# 16: mppt2_charger_temperature  °C (no ×0.1, note space before in format)
+# 17: pv1_charging_power    W
+# 18: pv2_charging_power    W
+# 19: pv1_input_voltage     ×0.1 V
+# 20: pv2_input_voltage     ×0.1 V
+# 21: setting_value_configuration_state  (binary)
+# 22: mppt1_charger_status  0=abnormal 1=normal_not_charging 2=charging
+# 23: mppt2_charger_status  0=abnormal 1=normal_not_charging 2=charging
+# 24: load_connection       0=disconnect 1=connect
+# 25: battery_power_direction  0=donothing 1=charge 2=discharge
+# 26: dc_ac_power_direction    0=donothing 1=AC-DC 2=DC-AC
+# 27: line_power_direction     0=donothing 1=input 2=output
+# 28: local_parallel_id
+
+# BanannaJoe — standby, PV charging only (no AC output)
+# Decoded: grid=231.2V/50.0Hz, output=0V, battery=51.8V/36%/4A_charging, pv1=30.2V/302W
+>>> 5E:50:30:30:35:47:53:58:14:0D
+<<< 5E:44:31:30:36:32:33:31:32:2C:35:30:30:2C:30:30:30:30:2C:30:30:30:2C:30:30:30:30:2C:30:30:30:30:2C:30:30:30:2C:35:31:38:2C:30:30:30:2C:30:30:30:2C:30:30:30:2C:30:30:34:2C:30:33:36:2C:30:32:37:2C:30:30:30:2C:30:30:30:2C:30:33:30:32:2C:30:30:30:30:2C:32:34:33:38:2C:30:30:30:30:2C:30:2C:32:2C:30:2C:30:2C:31:2C:32:2C:32:2C:30:DC:8E:0D
+
+# BeckoPopov — active load, solar+grid, 48V battery
+# Decoded: grid=242.2V/49.9Hz, output=230.5V/1475VA/1458W/26%, battery=52.6V/7%/0A, pv1=192.4V/0W
+>>> 5E:50:30:30:35:47:53:58:14:0D
+<<< 5E:44:31:30:36:32:34:32:32:2C:34:39:39:2C:32:33:30:35:2C:34:39:39:2C:31:34:37:35:2C:31:34:35:38:2C:30:32:36:2C:35:32:36:2C:30:30:30:2C:30:30:30:2C:30:30:30:2C:30:30:37:2C:30:38:34:2C:30:34:36:2C:30:30:30:2C:30:30:30:2C:31:39:32:34:2C:30:30:30:30:2C:32:36:35:34:2C:30:30:30:30:2C:30:2C:32:2C:30:2C:31:2C:31:2C:32:2C:30:2C:31:5C:E8:0D
+
+# BanannaJoe — repeated measurements (battery charging, standby AC output)
+# Decoded: grid=230.1V/49.9Hz, battery=52.2V/36%/9A_charging, pv1=243.6V/557W
+>>> 5E:50:30:30:35:47:53:58:14:0D
+<<< 5E:44:31:30:36:32:33:30:31:2C:34:39:39:2C:30:30:30:30:2C:30:30:30:2C:30:30:30:30:2C:30:30:30:30:2C:30:30:30:2C:35:32:32:2C:30:30:30:2C:30:30:30:2C:30:30:30:2C:30:30:39:2C:30:34:30:2C:30:33:32:2C:30:30:30:2C:30:30:30:2C:30:35:35:37:2C:30:30:30:30:2C:32:34:33:36:2C:30:30:30:30:2C:30:2C:32:2C:30:2C:30:2C:31:2C:32:2C:32:2C:30:13:0C:0D
+
+# --- ^P007PIRI (Device Ratings, 25 fields) ---
+#
+# Field mapping (sscanf "^D%3d%f,%f,%f,%f,%f,%d,%d,%f,%f,%f,%f,%f,%f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d"):
+#  1: grid_rating_voltage      ×0.1 V
+#  2: grid_rating_current      ×0.1 A
+#  3: ac_output_rating_voltage ×0.1 V
+#  4: ac_output_rating_frequency ×0.1 Hz
+#  5: ac_output_rating_current ×0.1 A
+#  6: ac_output_rating_apparent_power  VA
+#  7: ac_output_rating_active_power    W
+#  8: battery_rating_voltage   ×0.1 V
+#  9: battery_recharge_voltage ×0.1 V
+# 10: battery_redischarge_voltage ×0.1 V
+# 11: battery_under_voltage    ×0.1 V
+# 12: battery_bulk_voltage     ×0.1 V
+# 13: battery_float_voltage    ×0.1 V
+# 14: battery_type             0=AGM 1=Flooded 2=User
+# 15: current_max_ac_charging_current  A
+# 16: current_max_charging_current     A
+# 17: input_voltage_range      0=Appliances 1=UPS
+# 18: output_source_priority   0=Utility 1=Solar 2=SBU
+# 19: charger_source_priority  0=Utility 1=Solar 2=SolarFirst 3=SolarOnly
+# 20: parallel_max_num
+# 21: machine_type
+# 22: topology
+# 23: output_mode
+# 24: solar_power_priority
+# 25: mppt_string
+
+# BanannaJoe — 5600W 48V system, solar-first charger, 60A max charging
+# Decoded: rated 230V/24.3A/5600VA, battery 48V, bulk 55.4V, float 54.0V, charger=solar-first
+>>> 5E:50:30:30:37:50:49:52:49:EE:38:0D
+<<< 5E:44:30:38:39:32:33:30:30:2C:32:34:33:2C:32:33:30:30:2C:35:30:30:2C:32:34:33:2C:35:36:30:30:2C:35:36:30:30:2C:34:38:30:2C:35:30:30:2C:35:32:30:2C:34:38:30:2C:35:35:34:2C:35:34:30:2C:32:2C:30:31:30:2C:30:36:30:2C:30:2C:30:2C:32:2C:39:2C:31:2C:30:2C:30:2C:30:2C:31:2C:30:30:D6:78:0D
+
+# BeckoPopov — 5600W 48V, 90A max charging, solar+utility charger priority 2
+# Decoded: rated 230V/24.3A/5600VA, battery 48V, bulk 55.5V, float 54.4V, max_charge=90A
+>>> 5E:50:30:30:37:50:49:52:49:EE:38:0D
+<<< 5E:44:30:38:39:32:33:30:30:2C:32:34:33:2C:32:33:30:30:2C:35:30:30:2C:32:34:33:2C:35:36:30:30:2C:35:36:30:30:2C:34:38:30:2C:34:37:30:2C:35:33:30:2C:34:34:30:2C:35:35:35:2C:35:34:34:2C:32:2C:30:33:30:2C:30:39:30:2C:31:2C:31:2C:32:2C:39:2C:30:2C:30:2C:31:2C:30:2C:31:2C:30:30:82:AE:0D
+
+# --- ^P006MOD (Device Mode, single char) ---
+#
+# Response: ^D005<mode_code>  where mode code is a single digit
+# Known codes: 0=PowerOn 1=Standby 2=LinePower 3=BatteryMode 4=Fault 5=HybridMode
+
+# BeckoPopov — mode 3 (battery/hybrid)
+>>> 5E:50:30:30:36:4D:4F:44:B1:25:0D
+<<< 5E:44:30:30:35:30:33:B9:59:0D
+
+# BanannaJoe — mode 5 (hybrid)
+>>> 5E:50:30:30:36:4D:4F:44:B1:25:0D
+<<< 5E:44:30:30:35:30:35:D9:9F:0D
+
+# --- ^P007FLAG (Flags, 9 comma-separated 0/1 values) ---
+#
+# Fields: silence_buzzer, overload_bypass, lcd_escape, overload_restart,
+#         over_temp_restart, backlight_on, alarm_primary_interrupt, fault_record, power_saving
+
+# BeckoPopov — most flags enabled
+>>> 5E:50:30:30:37:46:4C:41:47:F5:E9:0D
+<<< 5E:44:30:32:30:31:2C:31:2C:31:2C:30:2C:30:2C:31:2C:30:2C:31:2C:30:F6:3D:0D
+
+# --- ^P005FWS (Fault/Warning Status) ---
+#
+# Response: ^D039<fault_code_2digits>,<w1>,<w2>,...,<w17>
+# Warnings: line_fail, output_short, over_temp, fan_lock, bat_high, bat_low_alarm,
+#           bat_shutdown, overload, eeprom, power_limit, pv1_high, pv2_high,
+#           mppt1_overload, mppt2_overload, scc1_low, scc2_low, (unused)
+
+# BeckoPopov / BanannaJoe — no active faults, eeprom warning only (w9=1)
+>>> 5E:50:30:30:35:46:57:53:17:5D:0D
+<<< 5E:44:30:33:39:30:30:2C:30:2C:30:2C:30:2C:30:2C:30:2C:30:2C:30:2C:30:2C:31:2C:30:2C:30:2C:30:2C:30:2C:30:2C:30:2C:30:2C:30:A6:7C:0D
+
+# --- ^P005ET (Total Generated Energy, 8-digit value in kWh) ---
+
+# BeckoPopov — 802946 kWh total
+>>> 5E:50:30:30:35:45:54:13:D9:0D
+<<< 5E:44:30:31:31:30:30:38:30:32:39:34:36:0E:79:0D
+
+# BanannaJoe — 320400 kWh total
+>>> 5E:50:30:30:35:45:54:13:D9:0D
+<<< 5E:44:30:31:31:30:30:33:32:30:34:30:30:8A:63:0D

--- a/esp32-pi18-example-debug.yaml
+++ b/esp32-pi18-example-debug.yaml
@@ -1,0 +1,27 @@
+<<: !include esp32-pi18-example.yaml
+
+logger:
+  level: VERY_VERBOSE
+  logs:
+    scheduler: DEBUG
+    component: DEBUG
+    mqtt: INFO
+    mqtt.idf: INFO
+    mqtt.component: INFO
+    mqtt.sensor: INFO
+    mqtt.switch: INFO
+    api.service: INFO
+    api: INFO
+
+uart:
+  id: uart_0
+  baud_rate: 2400
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+  debug:
+    direction: BOTH
+    dummy_receiver: false
+    after:
+      delimiter: "\r"
+    sequence:
+      - lambda: UARTDebug::log_string(direction, bytes);

--- a/esp32-pi18-example-faker.yaml
+++ b/esp32-pi18-example-faker.yaml
@@ -1,0 +1,1 @@
+<<: !include esp32-pi18-example-debug.yaml

--- a/esp32-pi18-example.yaml
+++ b/esp32-pi18-example.yaml
@@ -1,0 +1,436 @@
+substitutions:
+  name: pi18
+  external_components_source: github://syssi/esphome-pipsolar@main
+  tx_pin: GPIO16
+  rx_pin: GPIO17
+
+esphome:
+  name: ${name}
+  friendly_name: ${name}
+  project:
+    name: "syssi.esphome-pipsolar@main"
+    version: 1.0.0
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  baud_rate: 0
+  level: DEBUG
+
+# If you use Home Assistant please remove this `mqtt` section and uncomment the `api` component!
+# The native API has many advantages over MQTT: https://esphome.io/components/api.html#advantages-over-mqtt
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+# api:
+
+uart:
+  - id: uart_0
+    baud_rate: 2400
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+
+pi18:
+  uart_id: uart_0
+  id: inverter0
+
+sensor:
+  - platform: pi18
+    pipsolar_id: inverter0
+    # ^P005GS
+    grid_voltage:
+      name: "${name} Grid voltage"
+    grid_frequency:
+      name: "${name} Grid frequency"
+    ac_output_voltage:
+      name: "${name} AC output voltage"
+    ac_output_frequency:
+      name: "${name} AC output frequency"
+    ac_output_apparent_power:
+      name: "${name} AC output apparent power"
+    ac_output_active_power:
+      name: "${name} AC output active power"
+    output_load_percent:
+      name: "${name} Output load percent"
+    battery_voltage:
+      name: "${name} Battery voltage"
+    battery_voltage_scc:
+      name: "${name} Battery voltage SCC1"
+    battery_voltage_scc2:
+      name: "${name} Battery voltage SCC2"
+    battery_discharge_current:
+      name: "${name} Battery discharge current"
+    battery_charging_current:
+      name: "${name} Battery charging current"
+    battery_capacity_percent:
+      name: "${name} Battery capacity"
+    inverter_heat_sink_temperature:
+      name: "${name} Inverter heat sink temperature"
+    mppt1_charger_temperature:
+      name: "${name} MPPT1 charger temperature"
+    mppt2_charger_temperature:
+      name: "${name} MPPT2 charger temperature"
+    pv1_input_power:
+      name: "${name} PV1 input power"
+    pv2_input_power:
+      name: "${name} PV2 input power"
+    pv1_input_voltage:
+      name: "${name} PV1 input voltage"
+    pv2_input_voltage:
+      name: "${name} PV2 input voltage"
+    # ^P007PIRI
+    grid_rating_voltage:
+      name: "${name} Grid rating voltage"
+    grid_rating_current:
+      name: "${name} Grid rating current"
+    ac_output_rating_voltage:
+      name: "${name} AC output rating voltage"
+    ac_output_rating_frequency:
+      name: "${name} AC output rating frequency"
+    ac_output_rating_current:
+      name: "${name} AC output rating current"
+    ac_output_rating_apparent_power:
+      name: "${name} AC output rating apparent power"
+    ac_output_rating_active_power:
+      name: "${name} AC output rating active power"
+    battery_rating_voltage:
+      name: "${name} Battery rating voltage"
+    battery_recharge_voltage:
+      name: "${name} Battery recharge voltage"
+    battery_redischarge_voltage:
+      name: "${name} Battery redischarge voltage"
+    battery_under_voltage:
+      name: "${name} Battery under voltage"
+    battery_bulk_voltage:
+      name: "${name} Battery bulk voltage"
+    battery_float_voltage:
+      name: "${name} Battery float voltage"
+    battery_type:
+      name: "${name} Battery type"
+    current_max_ac_charging_current:
+      name: "${name} Max AC charging current"
+    current_max_charging_current:
+      name: "${name} Max charging current"
+    input_voltage_range:
+      name: "${name} Input voltage range"
+    output_source_priority:
+      name: "${name} Output source priority"
+    charger_source_priority:
+      name: "${name} Charger source priority"
+    parallel_max_num:
+      name: "${name} Parallel max num"
+    machine_type:
+      name: "${name} Machine type"
+    topology:
+      name: "${name} Topology"
+    output_mode:
+      name: "${name} Output mode"
+    solar_power_priority:
+      name: "${name} Solar power priority"
+    mppt_string:
+      name: "${name} MPPT string"
+    # ^P006MOD
+    device_mode_id:
+      name: "${name} Device mode id"
+    # ^P005ET
+    total_generated_energy:
+      name: "${name} Total generated energy"
+    # ^P005FWS
+    fault_code:
+      name: "${name} Fault code"
+    # ^P007PGS0 — parallel unit aggregate (only relevant for parallel setups)
+#    total_ac_output_apparent_power:
+#      name: "${name} Total AC output apparent power"
+#    total_ac_output_active_power:
+#      name: "${name} Total AC output active power"
+#    total_output_load_percent:
+#      name: "${name} Total output load percent"
+#    total_battery_charging_current:
+#      name: "${name} Total battery charging current"
+
+text_sensor:
+  - platform: pi18
+    pipsolar_id: inverter0
+    # ^P005GS
+    mppt1_charger_status:
+      name: "${name} MPPT1 charger status"
+    mppt2_charger_status:
+      name: "${name} MPPT2 charger status"
+    load_connection:
+      name: "${name} Load connection"
+    battery_power_direction:
+      name: "${name} Battery power direction"
+    dc_ac_power_direction:
+      name: "${name} DC/AC power direction"
+    line_power_direction:
+      name: "${name} Line power direction"
+    # ^P006MOD
+    device_mode:
+      name: "${name} Device mode"
+    # Raw responses (useful for debugging)
+#    last_p005gs:
+#      name: "${name} Last P005GS"
+#    last_p007piri:
+#      name: "${name} Last P007PIRI"
+#    last_p006mod:
+#      name: "${name} Last P006MOD"
+#    last_p007flag:
+#      name: "${name} Last P007FLAG"
+#    last_p005fws:
+#      name: "${name} Last P005FWS"
+#    last_p005et:
+#      name: "${name} Last P005ET"
+
+binary_sensor:
+  - platform: pi18
+    pipsolar_id: inverter0
+    # ^P005GS
+    setting_value_configuration_state:
+      name: "${name} Setting value configuration state"
+    # ^P007FLAG
+    silence_buzzer_open_buzzer:
+      name: "${name} Buzzer"
+    overload_bypass_function:
+      name: "${name} Overload bypass"
+    lcd_escape_to_default:
+      name: "${name} LCD escape to default"
+    overload_restart_function:
+      name: "${name} Overload restart"
+    over_temperature_restart_function:
+      name: "${name} Over temperature restart"
+    backlight_on:
+      name: "${name} Backlight"
+    alarm_on_when_primary_source_interrupt:
+      name: "${name} Alarm on primary source interrupt"
+    fault_code_record:
+      name: "${name} Fault code record"
+    power_saving:
+      name: "${name} Power saving"
+    # ^P005FWS
+    warning_line_fail:
+      name: "${name} Warning line fail"
+    warning_output_circuit_short:
+      name: "${name} Warning output circuit short"
+    warning_over_temperature:
+      name: "${name} Warning over temperature"
+    warning_fan_lock:
+      name: "${name} Warning fan lock"
+    warning_battery_voltage_high:
+      name: "${name} Warning battery voltage high"
+    warning_battery_low_alarm:
+      name: "${name} Warning battery low alarm"
+    warning_battery_under_shutdown:
+      name: "${name} Warning battery under shutdown"
+    warning_over_load:
+      name: "${name} Warning over load"
+    warning_eeprom_failed:
+      name: "${name} Warning EEPROM failed"
+    warning_power_limit:
+      name: "${name} Warning power limit"
+    warning_pv1_voltage_high:
+      name: "${name} Warning PV1 voltage high"
+    warning_pv2_voltage_high:
+      name: "${name} Warning PV2 voltage high"
+    warning_mppt1_overload:
+      name: "${name} Warning MPPT1 overload"
+    warning_mppt2_overload:
+      name: "${name} Warning MPPT2 overload"
+    warning_scc1_battery_too_low_to_charge:
+      name: "${name} Warning SCC1 battery too low to charge"
+    warning_scc2_battery_too_low_to_charge:
+      name: "${name} Warning SCC2 battery too low to charge"
+
+select:
+  - platform: pi18
+    pipsolar_id: inverter0
+    output_source_priority:
+      id: inverter0_output_source_priority_select
+      name: "${name} Output source priority"
+      optionsmap:
+        "Solar-Utility-Battery": "^S007POP0"
+        "Solar-Battery-Utility": "^S007POP1"
+      statusmap:
+        "0": "Solar-Utility-Battery"
+        "1": "Solar-Battery-Utility"
+  - platform: pi18
+    pipsolar_id: inverter0
+    charger_source_priority:
+      id: inverter0_charger_source_priority_select
+      name: "${name} Charger source priority"
+      optionsmap:
+        "Solar first": "^S009PCP0,0"
+        "Solar and Utility": "^S009PCP0,1"
+        "Only solar": "^S009PCP0,2"
+      statusmap:
+        "0": "Solar first"
+        "1": "Solar and Utility"
+        "2": "Only solar"
+  - platform: pi18
+    pipsolar_id: inverter0
+    solar_power_priority:
+      id: inverter0_solar_power_priority_select
+      name: "${name} Solar power priority"
+      optionsmap:
+        "Battery-Load-Utility (+AC Charge)": "^S007PSP0"
+        "Load-Battery-Utility": "^S007PSP1"
+      statusmap:
+        "0": "Battery-Load-Utility (+AC Charge)"
+        "1": "Load-Battery-Utility"
+  - platform: pi18
+    pipsolar_id: inverter0
+    input_voltage_range:
+      id: inverter0_input_voltage_range_select
+      name: "${name} Input voltage range"
+      optionsmap:
+        "Appliances 90-280V": "^S007PGR0"
+        "UPS 170-280V": "^S007PGR1"
+      statusmap:
+        "0": "Appliances 90-280V"
+        "1": "UPS 170-280V"
+  - platform: pi18
+    pipsolar_id: inverter0
+    machine_type:
+      id: inverter0_machine_type_select
+      name: "${name} Machine type"
+      optionsmap:
+        "OFF-Grid": "^S006PDI"
+        "Grid-Tie": "^S006PEI"
+      statusmap:
+        "0": "OFF-Grid"
+        "1": "Grid-Tie"
+  - platform: pi18
+    pipsolar_id: inverter0
+    current_max_ac_charging_current:
+      id: inverter0_current_max_ac_charging_current_select
+      name: "${name} Max AC charging current"
+      optionsmap:
+        "2A": "^S014MUCHGC0,002"
+        "10A": "^S014MUCHGC0,010"
+        "20A": "^S014MUCHGC0,020"
+        "30A": "^S014MUCHGC0,030"
+        "40A": "^S014MUCHGC0,040"
+        "50A": "^S014MUCHGC0,050"
+        "60A": "^S014MUCHGC0,060"
+        "70A": "^S014MUCHGC0,070"
+        "80A": "^S014MUCHGC0,080"
+      statusmap:
+        "2": "2A"
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+        "60": "60A"
+        "70": "70A"
+        "80": "80A"
+  - platform: pi18
+    pipsolar_id: inverter0
+    current_max_charging_current:
+      id: inverter0_current_max_charging_current_select
+      name: "${name} Max charging current"
+      optionsmap:
+        "10A": "^S013MCHGC0,010"
+        "20A": "^S013MCHGC0,020"
+        "30A": "^S013MCHGC0,030"
+        "40A": "^S013MCHGC0,040"
+        "50A": "^S013MCHGC0,050"
+        "60A": "^S013MCHGC0,060"
+        "70A": "^S013MCHGC0,070"
+        "80A": "^S013MCHGC0,080"
+        "90A": "^S013MCHGC0,090"
+      statusmap:
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+        "60": "60A"
+        "70": "70A"
+        "80": "80A"
+        "90": "90A"
+  - platform: pi18
+    pipsolar_id: inverter0
+    battery_under_voltage:
+      id: inverter0_battery_under_voltage_select
+      name: "${name} Battery cut-off voltage"
+      optionsmap:
+        "40V": "^S010PSDV400"
+        "41V": "^S010PSDV410"
+        "42V": "^S010PSDV420"
+        "43V": "^S010PSDV430"
+        "44V": "^S010PSDV440"
+        "45V": "^S010PSDV450"
+        "46V": "^S010PSDV460"
+        "47V": "^S010PSDV470"
+        "48V": "^S010PSDV480"
+      statusmap:
+        "400": "40V"
+        "410": "41V"
+        "420": "42V"
+        "430": "43V"
+        "440": "44V"
+        "450": "45V"
+        "460": "46V"
+        "470": "47V"
+        "480": "48V"
+
+output:
+  - platform: pi18
+    pipsolar_id: inverter0
+    current_max_ac_charging_current:
+      id: inverter0_current_max_ac_charging_current_out
+    current_max_charging_current:
+      id: inverter0_current_max_charging_current_out
+    battery_bulk_voltage:
+      id: inverter0_battery_bulk_voltage_out
+    battery_float_voltage:
+      id: inverter0_battery_float_voltage_out
+
+switch:
+  - platform: pi18
+    pipsolar_id: inverter0
+    output_source_priority:
+      name: "${name} Output source priority (solar first)"
+    solar_power_priority:
+      name: "${name} Solar power priority (load first)"
+    charger_source_priority_solarfirst:
+      name: "${name} Charger source priority solar first"
+    charger_source_priority_utility:
+      name: "${name} Charger source priority utility"
+    charger_source_priority_solaronly:
+      name: "${name} Charger source priority solar only"
+    silence_buzzer_open_buzzer:
+      name: "${name} Buzzer"
+    overload_bypass_function:
+      name: "${name} Overload bypass"
+    lcd_escape_to_default:
+      name: "${name} LCD escape to default"
+    overload_restart_function:
+      name: "${name} Overload restart"
+    over_temperature_restart_function:
+      name: "${name} Over temperature restart"
+    backlight_on:
+      name: "${name} Backlight"
+    alarm_on_when_primary_source_interrupt:
+      name: "${name} Alarm on primary source interrupt"
+    fault_code_record:
+      name: "${name} Fault code record"
+    power_saving:
+      name: "${name} Power saving"

--- a/esp8266-pi18-example-debug.yaml
+++ b/esp8266-pi18-example-debug.yaml
@@ -1,0 +1,27 @@
+<<: !include esp8266-pi18-example.yaml
+
+logger:
+  level: VERY_VERBOSE
+  logs:
+    scheduler: DEBUG
+    component: DEBUG
+    mqtt: INFO
+    mqtt.idf: INFO
+    mqtt.component: INFO
+    mqtt.sensor: INFO
+    mqtt.switch: INFO
+    api.service: INFO
+    api: INFO
+
+uart:
+  id: uart_0
+  baud_rate: 2400
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+  debug:
+    direction: BOTH
+    dummy_receiver: false
+    after:
+      delimiter: "\r"
+    sequence:
+      - lambda: UARTDebug::log_string(direction, bytes);

--- a/esp8266-pi18-example-faker.yaml
+++ b/esp8266-pi18-example-faker.yaml
@@ -1,0 +1,1 @@
+<<: !include esp8266-pi18-example-debug.yaml

--- a/esp8266-pi18-example.yaml
+++ b/esp8266-pi18-example.yaml
@@ -1,0 +1,435 @@
+substitutions:
+  name: pi18
+  external_components_source: github://syssi/esphome-pipsolar@main
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+esphome:
+  name: ${name}
+  friendly_name: ${name}
+  project:
+    name: "syssi.esphome-pipsolar@main"
+    version: 1.0.0
+
+esp8266:
+  board: d1_mini
+  enable_scanf_float: true
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  baud_rate: 0
+  level: DEBUG
+
+# If you use Home Assistant please remove this `mqtt` section and uncomment the `api` component!
+# The native API has many advantages over MQTT: https://esphome.io/components/api.html#advantages-over-mqtt
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+# api:
+
+uart:
+  - id: uart_0
+    baud_rate: 2400
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+
+pi18:
+  uart_id: uart_0
+  id: inverter0
+
+sensor:
+  - platform: pi18
+    pipsolar_id: inverter0
+    # ^P005GS
+    grid_voltage:
+      name: "${name} Grid voltage"
+    grid_frequency:
+      name: "${name} Grid frequency"
+    ac_output_voltage:
+      name: "${name} AC output voltage"
+    ac_output_frequency:
+      name: "${name} AC output frequency"
+    ac_output_apparent_power:
+      name: "${name} AC output apparent power"
+    ac_output_active_power:
+      name: "${name} AC output active power"
+    output_load_percent:
+      name: "${name} Output load percent"
+    battery_voltage:
+      name: "${name} Battery voltage"
+    battery_voltage_scc:
+      name: "${name} Battery voltage SCC1"
+    battery_voltage_scc2:
+      name: "${name} Battery voltage SCC2"
+    battery_discharge_current:
+      name: "${name} Battery discharge current"
+    battery_charging_current:
+      name: "${name} Battery charging current"
+    battery_capacity_percent:
+      name: "${name} Battery capacity"
+    inverter_heat_sink_temperature:
+      name: "${name} Inverter heat sink temperature"
+    mppt1_charger_temperature:
+      name: "${name} MPPT1 charger temperature"
+    mppt2_charger_temperature:
+      name: "${name} MPPT2 charger temperature"
+    pv1_input_power:
+      name: "${name} PV1 input power"
+    pv2_input_power:
+      name: "${name} PV2 input power"
+    pv1_input_voltage:
+      name: "${name} PV1 input voltage"
+    pv2_input_voltage:
+      name: "${name} PV2 input voltage"
+    # ^P007PIRI
+    grid_rating_voltage:
+      name: "${name} Grid rating voltage"
+    grid_rating_current:
+      name: "${name} Grid rating current"
+    ac_output_rating_voltage:
+      name: "${name} AC output rating voltage"
+    ac_output_rating_frequency:
+      name: "${name} AC output rating frequency"
+    ac_output_rating_current:
+      name: "${name} AC output rating current"
+    ac_output_rating_apparent_power:
+      name: "${name} AC output rating apparent power"
+    ac_output_rating_active_power:
+      name: "${name} AC output rating active power"
+    battery_rating_voltage:
+      name: "${name} Battery rating voltage"
+    battery_recharge_voltage:
+      name: "${name} Battery recharge voltage"
+    battery_redischarge_voltage:
+      name: "${name} Battery redischarge voltage"
+    battery_under_voltage:
+      name: "${name} Battery under voltage"
+    battery_bulk_voltage:
+      name: "${name} Battery bulk voltage"
+    battery_float_voltage:
+      name: "${name} Battery float voltage"
+    battery_type:
+      name: "${name} Battery type"
+    current_max_ac_charging_current:
+      name: "${name} Max AC charging current"
+    current_max_charging_current:
+      name: "${name} Max charging current"
+    input_voltage_range:
+      name: "${name} Input voltage range"
+    output_source_priority:
+      name: "${name} Output source priority"
+    charger_source_priority:
+      name: "${name} Charger source priority"
+    parallel_max_num:
+      name: "${name} Parallel max num"
+    machine_type:
+      name: "${name} Machine type"
+    topology:
+      name: "${name} Topology"
+    output_mode:
+      name: "${name} Output mode"
+    solar_power_priority:
+      name: "${name} Solar power priority"
+    mppt_string:
+      name: "${name} MPPT string"
+    # ^P006MOD
+    device_mode_id:
+      name: "${name} Device mode id"
+    # ^P005ET
+    total_generated_energy:
+      name: "${name} Total generated energy"
+    # ^P005FWS
+    fault_code:
+      name: "${name} Fault code"
+    # ^P007PGS0 — parallel unit aggregate (only relevant for parallel setups)
+#    total_ac_output_apparent_power:
+#      name: "${name} Total AC output apparent power"
+#    total_ac_output_active_power:
+#      name: "${name} Total AC output active power"
+#    total_output_load_percent:
+#      name: "${name} Total output load percent"
+#    total_battery_charging_current:
+#      name: "${name} Total battery charging current"
+
+text_sensor:
+  - platform: pi18
+    pipsolar_id: inverter0
+    # ^P005GS
+    mppt1_charger_status:
+      name: "${name} MPPT1 charger status"
+    mppt2_charger_status:
+      name: "${name} MPPT2 charger status"
+    load_connection:
+      name: "${name} Load connection"
+    battery_power_direction:
+      name: "${name} Battery power direction"
+    dc_ac_power_direction:
+      name: "${name} DC/AC power direction"
+    line_power_direction:
+      name: "${name} Line power direction"
+    # ^P006MOD
+    device_mode:
+      name: "${name} Device mode"
+    # Raw responses (useful for debugging)
+#    last_p005gs:
+#      name: "${name} Last P005GS"
+#    last_p007piri:
+#      name: "${name} Last P007PIRI"
+#    last_p006mod:
+#      name: "${name} Last P006MOD"
+#    last_p007flag:
+#      name: "${name} Last P007FLAG"
+#    last_p005fws:
+#      name: "${name} Last P005FWS"
+#    last_p005et:
+#      name: "${name} Last P005ET"
+
+binary_sensor:
+  - platform: pi18
+    pipsolar_id: inverter0
+    # ^P005GS
+    setting_value_configuration_state:
+      name: "${name} Setting value configuration state"
+    # ^P007FLAG
+    silence_buzzer_open_buzzer:
+      name: "${name} Buzzer"
+    overload_bypass_function:
+      name: "${name} Overload bypass"
+    lcd_escape_to_default:
+      name: "${name} LCD escape to default"
+    overload_restart_function:
+      name: "${name} Overload restart"
+    over_temperature_restart_function:
+      name: "${name} Over temperature restart"
+    backlight_on:
+      name: "${name} Backlight"
+    alarm_on_when_primary_source_interrupt:
+      name: "${name} Alarm on primary source interrupt"
+    fault_code_record:
+      name: "${name} Fault code record"
+    power_saving:
+      name: "${name} Power saving"
+    # ^P005FWS
+    warning_line_fail:
+      name: "${name} Warning line fail"
+    warning_output_circuit_short:
+      name: "${name} Warning output circuit short"
+    warning_over_temperature:
+      name: "${name} Warning over temperature"
+    warning_fan_lock:
+      name: "${name} Warning fan lock"
+    warning_battery_voltage_high:
+      name: "${name} Warning battery voltage high"
+    warning_battery_low_alarm:
+      name: "${name} Warning battery low alarm"
+    warning_battery_under_shutdown:
+      name: "${name} Warning battery under shutdown"
+    warning_over_load:
+      name: "${name} Warning over load"
+    warning_eeprom_failed:
+      name: "${name} Warning EEPROM failed"
+    warning_power_limit:
+      name: "${name} Warning power limit"
+    warning_pv1_voltage_high:
+      name: "${name} Warning PV1 voltage high"
+    warning_pv2_voltage_high:
+      name: "${name} Warning PV2 voltage high"
+    warning_mppt1_overload:
+      name: "${name} Warning MPPT1 overload"
+    warning_mppt2_overload:
+      name: "${name} Warning MPPT2 overload"
+    warning_scc1_battery_too_low_to_charge:
+      name: "${name} Warning SCC1 battery too low to charge"
+    warning_scc2_battery_too_low_to_charge:
+      name: "${name} Warning SCC2 battery too low to charge"
+
+select:
+  - platform: pi18
+    pipsolar_id: inverter0
+    output_source_priority:
+      id: inverter0_output_source_priority_select
+      name: "${name} Output source priority"
+      optionsmap:
+        "Solar-Utility-Battery": "^S007POP0"
+        "Solar-Battery-Utility": "^S007POP1"
+      statusmap:
+        "0": "Solar-Utility-Battery"
+        "1": "Solar-Battery-Utility"
+  - platform: pi18
+    pipsolar_id: inverter0
+    charger_source_priority:
+      id: inverter0_charger_source_priority_select
+      name: "${name} Charger source priority"
+      optionsmap:
+        "Solar first": "^S009PCP0,0"
+        "Solar and Utility": "^S009PCP0,1"
+        "Only solar": "^S009PCP0,2"
+      statusmap:
+        "0": "Solar first"
+        "1": "Solar and Utility"
+        "2": "Only solar"
+  - platform: pi18
+    pipsolar_id: inverter0
+    solar_power_priority:
+      id: inverter0_solar_power_priority_select
+      name: "${name} Solar power priority"
+      optionsmap:
+        "Battery-Load-Utility (+AC Charge)": "^S007PSP0"
+        "Load-Battery-Utility": "^S007PSP1"
+      statusmap:
+        "0": "Battery-Load-Utility (+AC Charge)"
+        "1": "Load-Battery-Utility"
+  - platform: pi18
+    pipsolar_id: inverter0
+    input_voltage_range:
+      id: inverter0_input_voltage_range_select
+      name: "${name} Input voltage range"
+      optionsmap:
+        "Appliances 90-280V": "^S007PGR0"
+        "UPS 170-280V": "^S007PGR1"
+      statusmap:
+        "0": "Appliances 90-280V"
+        "1": "UPS 170-280V"
+  - platform: pi18
+    pipsolar_id: inverter0
+    machine_type:
+      id: inverter0_machine_type_select
+      name: "${name} Machine type"
+      optionsmap:
+        "OFF-Grid": "^S006PDI"
+        "Grid-Tie": "^S006PEI"
+      statusmap:
+        "0": "OFF-Grid"
+        "1": "Grid-Tie"
+  - platform: pi18
+    pipsolar_id: inverter0
+    current_max_ac_charging_current:
+      id: inverter0_current_max_ac_charging_current_select
+      name: "${name} Max AC charging current"
+      optionsmap:
+        "2A": "^S014MUCHGC0,002"
+        "10A": "^S014MUCHGC0,010"
+        "20A": "^S014MUCHGC0,020"
+        "30A": "^S014MUCHGC0,030"
+        "40A": "^S014MUCHGC0,040"
+        "50A": "^S014MUCHGC0,050"
+        "60A": "^S014MUCHGC0,060"
+        "70A": "^S014MUCHGC0,070"
+        "80A": "^S014MUCHGC0,080"
+      statusmap:
+        "2": "2A"
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+        "60": "60A"
+        "70": "70A"
+        "80": "80A"
+  - platform: pi18
+    pipsolar_id: inverter0
+    current_max_charging_current:
+      id: inverter0_current_max_charging_current_select
+      name: "${name} Max charging current"
+      optionsmap:
+        "10A": "^S013MCHGC0,010"
+        "20A": "^S013MCHGC0,020"
+        "30A": "^S013MCHGC0,030"
+        "40A": "^S013MCHGC0,040"
+        "50A": "^S013MCHGC0,050"
+        "60A": "^S013MCHGC0,060"
+        "70A": "^S013MCHGC0,070"
+        "80A": "^S013MCHGC0,080"
+        "90A": "^S013MCHGC0,090"
+      statusmap:
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+        "60": "60A"
+        "70": "70A"
+        "80": "80A"
+        "90": "90A"
+  - platform: pi18
+    pipsolar_id: inverter0
+    battery_under_voltage:
+      id: inverter0_battery_under_voltage_select
+      name: "${name} Battery cut-off voltage"
+      optionsmap:
+        "40V": "^S010PSDV400"
+        "41V": "^S010PSDV410"
+        "42V": "^S010PSDV420"
+        "43V": "^S010PSDV430"
+        "44V": "^S010PSDV440"
+        "45V": "^S010PSDV450"
+        "46V": "^S010PSDV460"
+        "47V": "^S010PSDV470"
+        "48V": "^S010PSDV480"
+      statusmap:
+        "400": "40V"
+        "410": "41V"
+        "420": "42V"
+        "430": "43V"
+        "440": "44V"
+        "450": "45V"
+        "460": "46V"
+        "470": "47V"
+        "480": "48V"
+
+output:
+  - platform: pi18
+    pipsolar_id: inverter0
+    current_max_ac_charging_current:
+      id: inverter0_current_max_ac_charging_current_out
+    current_max_charging_current:
+      id: inverter0_current_max_charging_current_out
+    battery_bulk_voltage:
+      id: inverter0_battery_bulk_voltage_out
+    battery_float_voltage:
+      id: inverter0_battery_float_voltage_out
+
+switch:
+  - platform: pi18
+    pipsolar_id: inverter0
+    output_source_priority:
+      name: "${name} Output source priority (solar first)"
+    solar_power_priority:
+      name: "${name} Solar power priority (load first)"
+    charger_source_priority_solarfirst:
+      name: "${name} Charger source priority solar first"
+    charger_source_priority_utility:
+      name: "${name} Charger source priority utility"
+    charger_source_priority_solaronly:
+      name: "${name} Charger source priority solar only"
+    silence_buzzer_open_buzzer:
+      name: "${name} Buzzer"
+    overload_bypass_function:
+      name: "${name} Overload bypass"
+    lcd_escape_to_default:
+      name: "${name} LCD escape to default"
+    overload_restart_function:
+      name: "${name} Overload restart"
+    over_temperature_restart_function:
+      name: "${name} Over temperature restart"
+    backlight_on:
+      name: "${name} Backlight"
+    alarm_on_when_primary_source_interrupt:
+      name: "${name} Alarm on primary source interrupt"
+    fault_code_record:
+      name: "${name} Fault code record"
+    power_saving:
+      name: "${name} Power saving"

--- a/tests/components/pi18/common.h
+++ b/tests/components/pi18/common.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "esphome/components/pi18/pipsolar.h"
+
+namespace esphome::pi18::testing {
+
+class TestablePipsolar : public Pipsolar {
+ public:
+  using Pipsolar::handle_p005et_;
+  using Pipsolar::handle_p005fws_;
+  using Pipsolar::handle_p005gs_;
+  using Pipsolar::handle_p006mod_;
+  using Pipsolar::handle_p007flag_;
+  using Pipsolar::handle_p007pgs0_;
+  using Pipsolar::handle_p007piri_;
+};
+
+}  // namespace esphome::pi18::testing

--- a/tests/components/pi18/frames_lv5048.h
+++ b/tests/components/pi18/frames_lv5048.h
@@ -1,0 +1,186 @@
+#pragma once
+
+// PI18 frames recorded from LV5048 Hybrid V2 and compatible inverters.
+// Source: https://github.com/syssi/esphome-pipsolar/issues/54
+// Contributors: BanannaJoe (LV5048 Hybrid V2, 5600W, 48V) and BeckoPopov (LV5048 compatible)
+//
+// Frame strings represent read_buffer_ content after CRC verification:
+// leading '^' preserved, CRC bytes and CR zeroed (null-terminated).
+// Raw hex → ASCII with trailing [CRC_hi, CRC_lo, 0x0D] zeroed.
+
+namespace esphome::pi18::testing {
+
+// ── ^P005GS responses ─────────────────────────────────────────────────────────
+//
+// BanannaJoe — standby, PV only (no AC output, no grid)
+// grid=231.2V/50.0Hz, out=0V, bat=51.8V/36%/4A_charging
+// pv1=243.8V/302W, mppt1=charging(2), mppt2=abnormal(0)
+// bat_dir=charge(1), dc_ac_dir=DC-AC(2), line_dir=output(2), load_conn=disconnect(0)
+static const char LV5048_P005GS_STANDBY_PV[] =
+    "^D1062312,500,0000,000,00000,00000,000,518,000,000,000,004,036,027,000,000,0302,0000,2438,0000,0,2,0,0,1,2,2,0";
+
+// BeckoPopov — active load, solar+grid, 48V battery
+// grid=242.2V/49.9Hz, out=230.5V/1475VA/1458W/26%
+// bat=52.6V/84%/7A_charging, pv1=265.4V/1924W
+// mppt1=charging(2), mppt2=abnormal(0)
+// load_conn=connect(1), bat_dir=charge(1), dc_ac_dir=DC-AC(2), line_dir=donothing(0)
+static const char LV5048_P005GS_ACTIVE[] =
+    "^D1062422,499,2305,499,1475,1458,026,526,000,000,000,007,084,046,000,000,1924,0000,2654,0000,0,2,0,1,1,2,0,1";
+
+// BanannaJoe — repeated measurement (battery charging, standby AC output)
+// grid=230.1V/49.9Hz, bat=52.2V/40%/9A_charging, pv1=243.6V/557W
+static const char LV5048_P005GS_CHARGING[] =
+    "^D1062301,499,0000,000,00000,00000,000,522,000,000,000,009,040,032,000,000,0557,0000,2436,0000,0,2,0,0,1,2,2,0";
+
+// ── ^P007PIRI responses ───────────────────────────────────────────────────────
+//
+// BanannaJoe — 5600W 48V system, solar-first charger, 60A max charging
+// rated: 230V/24.3A/5600VA, battery 48V, bulk 55.4V, float 54.0V
+// charger=solar-first(2), out_priority=utility(0), max_ac_chg=10A, max_chg=60A
+static const char LV5048_P007PIRI_BANANNAJOE[] =
+    "^D0892300,243,2300,500,243,5600,5600,480,500,520,480,554,540,2,010,060,0,0,2,9,1,0,0,0,1,00";
+
+// BeckoPopov — 5600W 48V, 90A max charging, solar+utility charger priority 2
+// rated: 230V/24.3A/5600VA, battery 48V, bulk 55.5V, float 54.4V, max_chg=90A
+static const char LV5048_P007PIRI_BECKOPOPOV[] =
+    "^D0892300,243,2300,500,243,5600,5600,480,470,530,440,555,544,2,030,090,1,1,2,9,0,0,1,0,1,00";
+
+// ── ^P006MOD responses ────────────────────────────────────────────────────────
+//
+// BeckoPopov — mode 3 (battery/hybrid)
+static const char LV5048_P006MOD_BATTERY[] = "^D00503";
+
+// BanannaJoe — mode 5 (hybrid)
+static const char LV5048_P006MOD_HYBRID[] = "^D00505";
+
+// ── ^P007PGS0 responses ───────────────────────────────────────────────────────
+//
+// Single unit in parallel system, unit 0 idle (no grid, no AC output),
+// aggregate: 12338 VA / 12336 W from other units, total_chg=337 A
+static const char LV5048_P007PGS0_ACTIVE[] = "^D1131,0,00,0000,171,0000,000,0000,0000,12338,12336,000,000,257,337,257,"
+                                             "337,000,5535,2345,0514,0000,0,0,0,0,0,0,051";
+
+// ── ^P007FLAG responses ───────────────────────────────────────────────────────
+//
+// BeckoPopov — silence_buzzer=1, overload_bypass=1, lcd_escape=1, overload_restart=0,
+//              over_temp_restart=0, backlight=1, alarm=0, fault_record=1, power_saving=0
+static const char LV5048_P007FLAG[] = "^D0201,1,1,0,0,1,0,1,0";
+
+// ── ^P005FWS responses ────────────────────────────────────────────────────────
+//
+// No active faults; eeprom warning active (w9=1, zero-indexed w[8])
+static const char LV5048_P005FWS_EEPROM_WARN[] = "^D03900,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0";
+
+// ── ^P005ET responses ─────────────────────────────────────────────────────────
+//
+// BeckoPopov — 802946 kWh total generated
+static const char LV5048_P005ET_BECKOPOPOV[] = "^D01100802946";
+
+// BanannaJoe — 320400 kWh total generated
+static const char LV5048_P005ET_BANANNAJOE[] = "^D01100320400";
+
+// ── ^P004T responses ──────────────────────────────────────────────────────────
+//
+// >>> ^P004T  (query current device time)
+// <<< ^D017<YYYYMMDDHHmmss>
+//
+// BeckoPopov — 2023-03-20 11:46:13
+static const char LV5048_P004T[] = "^D01720230320114613";
+
+// ── ^P005ACCT responses ───────────────────────────────────────────────────────
+//
+// >>> ^P005ACCT  (AC charger time totals)
+// <<< ^D012<charge_time>,<load_time>  (unit unknown, likely minutes)
+//
+// Both zero on a freshly configured system
+static const char LV5048_P005ACCT[] = "^D0120000,0000";
+
+// ── ^P005ACLT responses ───────────────────────────────────────────────────────
+//
+// >>> ^P005ACLT  (AC load time totals)
+// <<< ^D012<load_time_1>,<load_time_2>
+//
+// Both zero on a freshly configured system
+static const char LV5048_P005ACLT[] = "^D0120000,0000";
+
+// ── ^P005DI responses ─────────────────────────────────────────────────────────
+//
+// >>> ^P005DI  (default / factory settings, 23 comma-separated fields)
+// <<< ^D068<ac_in_v>,<ac_in_f>,<ac_in_range>,<bat_absorb_v>,<bat_bulk_v>,
+//            <bat_float_v>,<bat_recharge_v>,<bat_redischarge_v>,<max_chg_a>,
+//            <input_v_range>,<out_src_priority>,<chg_src_priority>,<bat_type>,
+//            <buzzer>,<overload_bypass>,<lcd_escape>,<overload_restart>,
+//            <over_temp_restart>,<backlight>,<alarm>,<fault_record>,
+//            <power_saving>,<bat_equalization>
+//
+// BeckoPopov — 230V/50Hz grid, 48V battery (bulk=56.4V, float=54.0V, recharge=46.0V)
+static const char LV5048_P005DI[] = "^D0682300,500,0,408,540,564,460,540,060,30,0,0,1,0,0,0,1,0,0,1,1,0,1,1";
+
+// ── ^P005ID responses ─────────────────────────────────────────────────────────
+//
+// >>> ^P005ID  (product ID / serial number, 22-char string)
+// <<< ^D025<serial_number_22_chars>
+//
+// BeckoPopov — serial: 1496132209100190000000
+static const char LV5048_P005ID[] = "^D0251496132209100190000000";
+
+// ── ^P005PI responses ─────────────────────────────────────────────────────────
+//
+// >>> ^P005PI  (product info / protocol version, 2 chars)
+// <<< ^D005<protocol_id_2chars>
+//
+// BeckoPopov — protocol identifier "18" (PI18)
+static const char LV5048_P005PI[] = "^D00518";
+
+// ── ^P006VFW responses ────────────────────────────────────────────────────────
+//
+// >>> ^P006VFW  (firmware versions, 3 × 5-digit fields)
+// <<< ^D020<fw_main>,<fw_secondary>,<fw_reserved>
+//
+// BeckoPopov — main=07601, secondary=08028, reserved=00000
+static const char LV5048_P006VFW[] = "^D02007601,08028,00000";
+
+// ── ^P007PRI responses ────────────────────────────────────────────────────────
+//
+// >>> ^P007PRI  (parallel rated info, per-unit)
+// <<< ^D040<unit_id>,<work_mode>,<fault_code>,\x02<fw_version_str>,<...>,<...>,<...>
+//
+// Note: the \x02 byte (STX) appears to delimit a free-form firmware/version
+// field; exact sub-field layout is not yet fully documented.
+//
+// BeckoPopov — unit 0, mode 1, no fault; fw-string contains "020"
+static const char LV5048_P007PRI_UNIT0[] = "^D0401,00,0\x02"
+                                           "001 020  00.000000,0,000,000,0";
+
+// BeckoPopov — unit 1, mode 1, no fault; fw-string contains "010"
+static const char LV5048_P007PRI_UNIT1[] = "^D0401,00,0\x02"
+                                           "001 010  00.000000,0,000,000,0";
+
+// ── ^P009MCHGCR responses ─────────────────────────────────────────────────────
+//
+// >>> ^P009MCHGCR  (valid max-charging-current values, comma-separated)
+// <<< ^D050<a1>,<a2>,...,<aN>  (in amperes, 3-digit zero-padded)
+//
+// BeckoPopov — 12 steps: 10 A – 120 A in 10 A increments
+static const char LV5048_P009MCHGCR[] = "^D050010,020,030,040,050,060,070,080,090,100,110,120";
+
+// ── ^P005FWS (synthetic test vector) ─────────────────────────────────────────
+//
+// Not a captured frame — exercises non-zero fault_code and true paths for
+// w[0..4]: line_fail, output_short, over_temp, fan_lock, bat_voltage_high.
+static const char LV5048_P005FWS_MULTI_FAULT[] = "^D03905,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0";
+
+// ── Unsupported-command responses ─────────────────────────────────────────────
+//
+// Commands not implemented by this firmware return a non-standard NAK:
+// ^0 + CRC(2) + CR  (i.e. '^' 0x30 instead of the usual "(NAK").
+// Observed for: ^P009EY, ^P011EM, ^P013ED (daily/monthly energy history).
+//
+// Stored as the 2-byte payload after CRC stripping:
+static const char LV5048_RESPONSE_UNSUPPORTED[] = "^0";
+
+// Standard PI18 NAK (e.g. response to malformed ^MUCHGCR):
+// "(NAK" + CRC(2) + CR  — payload after CRC stripping is "(NAK"
+static const char LV5048_RESPONSE_NAK[] = "(NAK";
+
+}  // namespace esphome::pi18::testing

--- a/tests/components/pi18/pi18_lv5048_test.cpp
+++ b/tests/components/pi18/pi18_lv5048_test.cpp
@@ -1,0 +1,506 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include "common.h"
+#include "frames_lv5048.h"
+
+namespace esphome::pi18::testing {
+
+// ── P005GS ────────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P005gsGridMeasurements) {
+  TestablePipsolar inv;
+  sensor::Sensor grid_v, grid_hz;
+  inv.set_grid_voltage(&grid_v);
+  inv.set_grid_frequency(&grid_hz);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_NEAR(grid_v.state, 231.2f, 0.01f);
+  EXPECT_NEAR(grid_hz.state, 50.0f, 0.01f);
+}
+
+TEST(Pi18Lv5048Test, P005gsOutputZeroInStandby) {
+  TestablePipsolar inv;
+  sensor::Sensor out_v, out_hz, apparent, active, load_pct;
+  inv.set_ac_output_voltage(&out_v);
+  inv.set_ac_output_frequency(&out_hz);
+  inv.set_ac_output_apparent_power(&apparent);
+  inv.set_ac_output_active_power(&active);
+  inv.set_output_load_percent(&load_pct);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_FLOAT_EQ(out_v.state, 0.0f);
+  EXPECT_FLOAT_EQ(out_hz.state, 0.0f);
+  EXPECT_FLOAT_EQ(apparent.state, 0.0f);
+  EXPECT_FLOAT_EQ(active.state, 0.0f);
+  EXPECT_FLOAT_EQ(load_pct.state, 0.0f);
+}
+
+TEST(Pi18Lv5048Test, P005gsBatteryCharging) {
+  TestablePipsolar inv;
+  sensor::Sensor bat_v, chg_a, cap_pct, heat;
+  inv.set_battery_voltage(&bat_v);
+  inv.set_battery_charging_current(&chg_a);
+  inv.set_battery_capacity_percent(&cap_pct);
+  inv.set_inverter_heat_sink_temperature(&heat);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_NEAR(bat_v.state, 51.8f, 0.01f);
+  EXPECT_FLOAT_EQ(chg_a.state, 4.0f);
+  EXPECT_FLOAT_EQ(cap_pct.state, 36.0f);
+  EXPECT_FLOAT_EQ(heat.state, 27.0f);
+}
+
+TEST(Pi18Lv5048Test, P005gsBatteryDischargeCurrentNegated) {
+  TestablePipsolar inv;
+  sensor::Sensor dis_a;
+  inv.set_battery_discharge_current(&dis_a);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_FLOAT_EQ(dis_a.state, 0.0f);
+}
+
+TEST(Pi18Lv5048Test, P005gsPvInputStandby) {
+  TestablePipsolar inv;
+  sensor::Sensor pv1_pwr, pv1_v, pv2_pwr, pv2_v;
+  inv.set_pv1_input_power(&pv1_pwr);
+  inv.set_pv1_input_voltage(&pv1_v);
+  inv.set_pv2_input_power(&pv2_pwr);
+  inv.set_pv2_input_voltage(&pv2_v);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_NEAR(pv1_pwr.state, 302.0f, 0.1f);
+  EXPECT_NEAR(pv1_v.state, 243.8f, 0.01f);
+  EXPECT_NEAR(pv2_pwr.state, 0.0f, 0.1f);
+  EXPECT_NEAR(pv2_v.state, 0.0f, 0.01f);
+}
+
+TEST(Pi18Lv5048Test, P005gsMpptChargerStatus) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor mppt1, mppt2;
+  inv.set_mppt1_charger_status(&mppt1);
+  inv.set_mppt2_charger_status(&mppt2);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_STREQ(mppt1.state.c_str(), "charging");
+  EXPECT_STREQ(mppt2.state.c_str(), "abnormal");
+}
+
+TEST(Pi18Lv5048Test, P005gsLoadConnection) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor load;
+  inv.set_load_connection(&load);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_STREQ(load.state.c_str(), "disconnect");
+
+  TestablePipsolar inv2;
+  text_sensor::TextSensor load2;
+  inv2.set_load_connection(&load2);
+  inv2.handle_p005gs_(LV5048_P005GS_ACTIVE);
+  EXPECT_STREQ(load2.state.c_str(), "connect");
+}
+
+TEST(Pi18Lv5048Test, P005gsBatteryPowerDirection) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor bat_dir;
+  inv.set_battery_power_direction(&bat_dir);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_STREQ(bat_dir.state.c_str(), "charge");
+}
+
+TEST(Pi18Lv5048Test, P005gsDcAcPowerDirection) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor dc_ac;
+  inv.set_dc_ac_power_direction(&dc_ac);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_STREQ(dc_ac.state.c_str(), "DC-AC");
+}
+
+TEST(Pi18Lv5048Test, P005gsLinePowerDirection) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor line;
+  inv.set_line_power_direction(&line);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_STREQ(line.state.c_str(), "output");
+}
+
+TEST(Pi18Lv5048Test, P005gsAcOutputFrequencyActive) {
+  TestablePipsolar inv;
+  sensor::Sensor out_hz;
+  inv.set_ac_output_frequency(&out_hz);
+  inv.handle_p005gs_(LV5048_P005GS_ACTIVE);
+  EXPECT_NEAR(out_hz.state, 49.9f, 0.01f);
+}
+
+TEST(Pi18Lv5048Test, P005gsZeroFieldsInStandby) {
+  TestablePipsolar inv;
+  sensor::Sensor bat_scc, bat_scc2, mppt1_temp, mppt2_temp, pv2_pwr, pv2_v;
+  binary_sensor::BinarySensor config_state;
+  inv.set_battery_voltage_scc(&bat_scc);
+  inv.set_battery_voltage_scc2(&bat_scc2);
+  inv.set_mppt1_charger_temperature(&mppt1_temp);
+  inv.set_mppt2_charger_temperature(&mppt2_temp);
+  inv.set_pv2_input_power(&pv2_pwr);
+  inv.set_pv2_input_voltage(&pv2_v);
+  inv.set_setting_value_configuration_state(&config_state);
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  EXPECT_FLOAT_EQ(bat_scc.state, 0.0f);
+  EXPECT_FLOAT_EQ(bat_scc2.state, 0.0f);
+  EXPECT_FLOAT_EQ(mppt1_temp.state, 0.0f);
+  EXPECT_FLOAT_EQ(mppt2_temp.state, 0.0f);
+  EXPECT_FLOAT_EQ(pv2_pwr.state, 0.0f);
+  EXPECT_FLOAT_EQ(pv2_v.state, 0.0f);
+  EXPECT_FALSE(config_state.state);
+}
+
+TEST(Pi18Lv5048Test, P005gsActiveLoadBeckoPopov) {
+  TestablePipsolar inv;
+  sensor::Sensor grid_v, out_v, apparent, active, load_pct, bat_v, chg_a, cap_pct;
+  inv.set_grid_voltage(&grid_v);
+  inv.set_ac_output_voltage(&out_v);
+  inv.set_ac_output_apparent_power(&apparent);
+  inv.set_ac_output_active_power(&active);
+  inv.set_output_load_percent(&load_pct);
+  inv.set_battery_voltage(&bat_v);
+  inv.set_battery_charging_current(&chg_a);
+  inv.set_battery_capacity_percent(&cap_pct);
+  inv.handle_p005gs_(LV5048_P005GS_ACTIVE);
+  EXPECT_NEAR(grid_v.state, 242.2f, 0.01f);
+  EXPECT_NEAR(out_v.state, 230.5f, 0.01f);
+  EXPECT_FLOAT_EQ(apparent.state, 1475.0f);
+  EXPECT_FLOAT_EQ(active.state, 1458.0f);
+  EXPECT_FLOAT_EQ(load_pct.state, 26.0f);
+  EXPECT_NEAR(bat_v.state, 52.6f, 0.01f);
+  EXPECT_FLOAT_EQ(chg_a.state, 7.0f);
+  EXPECT_FLOAT_EQ(cap_pct.state, 84.0f);
+}
+
+TEST(Pi18Lv5048Test, P005gsChargingCycleValues) {
+  TestablePipsolar inv;
+  sensor::Sensor bat_v, chg_a, cap_pct, pv1_pwr, pv1_v;
+  inv.set_battery_voltage(&bat_v);
+  inv.set_battery_charging_current(&chg_a);
+  inv.set_battery_capacity_percent(&cap_pct);
+  inv.set_pv1_input_power(&pv1_pwr);
+  inv.set_pv1_input_voltage(&pv1_v);
+  inv.handle_p005gs_(LV5048_P005GS_CHARGING);
+  EXPECT_NEAR(bat_v.state, 52.2f, 0.01f);
+  EXPECT_FLOAT_EQ(chg_a.state, 9.0f);
+  EXPECT_FLOAT_EQ(cap_pct.state, 40.0f);
+  EXPECT_NEAR(pv1_pwr.state, 557.0f, 0.1f);
+  EXPECT_NEAR(pv1_v.state, 243.6f, 0.01f);
+}
+
+// ── P007PIRI ──────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P007piriRatedVoltagesAndCurrents) {
+  TestablePipsolar inv;
+  sensor::Sensor grid_v, grid_a, out_v, out_hz, out_a, apparent, active;
+  inv.set_grid_rating_voltage(&grid_v);
+  inv.set_grid_rating_current(&grid_a);
+  inv.set_ac_output_rating_voltage(&out_v);
+  inv.set_ac_output_rating_frequency(&out_hz);
+  inv.set_ac_output_rating_current(&out_a);
+  inv.set_ac_output_rating_apparent_power(&apparent);
+  inv.set_ac_output_rating_active_power(&active);
+  inv.handle_p007piri_(LV5048_P007PIRI_BANANNAJOE);
+  EXPECT_NEAR(grid_v.state, 230.0f, 0.01f);
+  EXPECT_NEAR(grid_a.state, 24.3f, 0.01f);
+  EXPECT_NEAR(out_v.state, 230.0f, 0.01f);
+  EXPECT_NEAR(out_hz.state, 50.0f, 0.01f);
+  EXPECT_NEAR(out_a.state, 24.3f, 0.01f);
+  EXPECT_FLOAT_EQ(apparent.state, 5600.0f);
+  EXPECT_FLOAT_EQ(active.state, 5600.0f);
+}
+
+TEST(Pi18Lv5048Test, P007piriBatteryVoltagesBanannaJoe) {
+  TestablePipsolar inv;
+  sensor::Sensor rating_v, recharge_v, redischarge_v, under_v, bulk_v, float_v;
+  inv.set_battery_rating_voltage(&rating_v);
+  inv.set_battery_recharge_voltage(&recharge_v);
+  inv.set_battery_redischarge_voltage(&redischarge_v);
+  inv.set_battery_under_voltage(&under_v);
+  inv.set_battery_bulk_voltage(&bulk_v);
+  inv.set_battery_float_voltage(&float_v);
+  inv.handle_p007piri_(LV5048_P007PIRI_BANANNAJOE);
+  EXPECT_NEAR(rating_v.state, 48.0f, 0.01f);
+  EXPECT_NEAR(recharge_v.state, 50.0f, 0.01f);
+  EXPECT_NEAR(redischarge_v.state, 52.0f, 0.01f);
+  EXPECT_NEAR(under_v.state, 48.0f, 0.01f);
+  EXPECT_NEAR(bulk_v.state, 55.4f, 0.01f);
+  EXPECT_NEAR(float_v.state, 54.0f, 0.01f);
+}
+
+TEST(Pi18Lv5048Test, P007piriChargingCurrentsBanannaJoe) {
+  TestablePipsolar inv;
+  sensor::Sensor max_ac_chg, max_chg;
+  inv.set_current_max_ac_charging_current(&max_ac_chg);
+  inv.set_current_max_charging_current(&max_chg);
+  inv.handle_p007piri_(LV5048_P007PIRI_BANANNAJOE);
+  EXPECT_FLOAT_EQ(max_ac_chg.state, 10.0f);
+  EXPECT_FLOAT_EQ(max_chg.state, 60.0f);
+}
+
+TEST(Pi18Lv5048Test, P007piriSourcePrioritiesBanannaJoe) {
+  TestablePipsolar inv;
+  sensor::Sensor out_prio, chg_prio;
+  inv.set_output_source_priority(&out_prio);
+  inv.set_charger_source_priority(&chg_prio);
+  inv.handle_p007piri_(LV5048_P007PIRI_BANANNAJOE);
+  EXPECT_FLOAT_EQ(out_prio.state, 0.0f);  // 0=utility
+  EXPECT_FLOAT_EQ(chg_prio.state, 2.0f);  // 2=solar first
+}
+
+TEST(Pi18Lv5048Test, P007piriUntestedFieldsBanannaJoe) {
+  TestablePipsolar inv;
+  sensor::Sensor bat_type, par_max, machine, topo, out_mode, solar_prio, mppt_str;
+  inv.set_battery_type(&bat_type);
+  inv.set_parallel_max_num(&par_max);
+  inv.set_machine_type(&machine);
+  inv.set_topology(&topo);
+  inv.set_output_mode(&out_mode);
+  inv.set_solar_power_priority(&solar_prio);
+  inv.set_mppt_string(&mppt_str);
+  inv.handle_p007piri_(LV5048_P007PIRI_BANANNAJOE);
+  EXPECT_FLOAT_EQ(bat_type.state, 2.0f);
+  EXPECT_FLOAT_EQ(par_max.state, 9.0f);
+  EXPECT_FLOAT_EQ(machine.state, 1.0f);
+  EXPECT_FLOAT_EQ(topo.state, 0.0f);
+  EXPECT_FLOAT_EQ(out_mode.state, 0.0f);
+  EXPECT_FLOAT_EQ(solar_prio.state, 0.0f);
+  EXPECT_FLOAT_EQ(mppt_str.state, 1.0f);
+}
+
+TEST(Pi18Lv5048Test, P007piriUntestedFieldsBeckoPopov) {
+  TestablePipsolar inv;
+  sensor::Sensor bat_type, machine, input_range, out_prio, out_mode, mppt_str, max_ac_chg;
+  inv.set_battery_type(&bat_type);
+  inv.set_machine_type(&machine);
+  inv.set_input_voltage_range(&input_range);
+  inv.set_output_source_priority(&out_prio);
+  inv.set_output_mode(&out_mode);
+  inv.set_mppt_string(&mppt_str);
+  inv.set_current_max_ac_charging_current(&max_ac_chg);
+  inv.handle_p007piri_(LV5048_P007PIRI_BECKOPOPOV);
+  EXPECT_FLOAT_EQ(bat_type.state, 2.0f);
+  EXPECT_FLOAT_EQ(machine.state, 0.0f);
+  EXPECT_FLOAT_EQ(input_range.state, 1.0f);
+  EXPECT_FLOAT_EQ(out_prio.state, 1.0f);
+  EXPECT_FLOAT_EQ(out_mode.state, 1.0f);
+  EXPECT_FLOAT_EQ(mppt_str.state, 1.0f);
+  EXPECT_FLOAT_EQ(max_ac_chg.state, 30.0f);
+}
+
+TEST(Pi18Lv5048Test, P007piriBatteryVoltagesBeckoPopov) {
+  TestablePipsolar inv;
+  sensor::Sensor bulk_v, float_v, max_chg;
+  inv.set_battery_bulk_voltage(&bulk_v);
+  inv.set_battery_float_voltage(&float_v);
+  inv.set_current_max_charging_current(&max_chg);
+  inv.handle_p007piri_(LV5048_P007PIRI_BECKOPOPOV);
+  EXPECT_NEAR(bulk_v.state, 55.5f, 0.01f);
+  EXPECT_NEAR(float_v.state, 54.4f, 0.01f);
+  EXPECT_FLOAT_EQ(max_chg.state, 90.0f);
+}
+
+// ── P006MOD ───────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P006modBatteryMode) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor mode;
+  sensor::Sensor mode_id;
+  inv.set_device_mode(&mode);
+  inv.set_device_mode_id(&mode_id);
+  inv.handle_p006mod_(LV5048_P006MOD_BATTERY);
+  EXPECT_STREQ(mode.state.c_str(), "Battery mode");
+  EXPECT_EQ(mode_id.state, 3);
+}
+
+TEST(Pi18Lv5048Test, P006modHybridMode) {
+  TestablePipsolar inv;
+  text_sensor::TextSensor mode;
+  sensor::Sensor mode_id;
+  inv.set_device_mode(&mode);
+  inv.set_device_mode_id(&mode_id);
+  inv.handle_p006mod_(LV5048_P006MOD_HYBRID);
+  EXPECT_STREQ(mode.state.c_str(), "Hybrid mode");
+  EXPECT_EQ(mode_id.state, 5);
+}
+
+// ── P007FLAG ──────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P007flagEnabledFlags) {
+  TestablePipsolar inv;
+  binary_sensor::BinarySensor buzzer, bypass, lcd;
+  binary_sensor::BinarySensor backlight, fault_rec;
+  inv.set_silence_buzzer_open_buzzer(&buzzer);
+  inv.set_overload_bypass_function(&bypass);
+  inv.set_lcd_escape_to_default(&lcd);
+  inv.set_backlight_on(&backlight);
+  inv.set_fault_code_record(&fault_rec);
+  inv.handle_p007flag_(LV5048_P007FLAG);
+  EXPECT_TRUE(buzzer.state);
+  EXPECT_TRUE(bypass.state);
+  EXPECT_TRUE(lcd.state);
+  EXPECT_TRUE(backlight.state);
+  EXPECT_TRUE(fault_rec.state);
+}
+
+TEST(Pi18Lv5048Test, P007flagDisabledFlags) {
+  TestablePipsolar inv;
+  binary_sensor::BinarySensor overload_restart, over_temp, alarm, power_save;
+  inv.set_overload_restart_function(&overload_restart);
+  inv.set_over_temperature_restart_function(&over_temp);
+  inv.set_alarm_on_when_primary_source_interrupt(&alarm);
+  inv.set_power_saving(&power_save);
+  inv.handle_p007flag_(LV5048_P007FLAG);
+  EXPECT_FALSE(overload_restart.state);
+  EXPECT_FALSE(over_temp.state);
+  EXPECT_FALSE(alarm.state);
+  EXPECT_FALSE(power_save.state);
+}
+
+// ── P005FWS ───────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P005fwsEepromWarningActive) {
+  TestablePipsolar inv;
+  binary_sensor::BinarySensor eeprom;
+  sensor::Sensor fault_code;
+  inv.set_warning_eeprom_failed(&eeprom);
+  inv.set_fault_code(&fault_code);
+  inv.handle_p005fws_(LV5048_P005FWS_EEPROM_WARN);
+  EXPECT_TRUE(eeprom.state);
+  EXPECT_FLOAT_EQ(fault_code.state, 0.0f);
+}
+
+TEST(Pi18Lv5048Test, P005fwsAllOtherWarningsClear) {
+  TestablePipsolar inv;
+  binary_sensor::BinarySensor line_fail, output_short, over_temp, fan_lock;
+  binary_sensor::BinarySensor bat_high, bat_low, bat_shutdown, overload;
+  binary_sensor::BinarySensor power_limit, pv1_high, pv2_high;
+  binary_sensor::BinarySensor mppt1_ovld, mppt2_ovld, scc1_low, scc2_low;
+  inv.set_warning_line_fail(&line_fail);
+  inv.set_warning_output_circuit_short(&output_short);
+  inv.set_warning_over_temperature(&over_temp);
+  inv.set_warning_fan_lock(&fan_lock);
+  inv.set_warning_battery_voltage_high(&bat_high);
+  inv.set_warning_battery_low_alarm(&bat_low);
+  inv.set_warning_battery_under_shutdown(&bat_shutdown);
+  inv.set_warning_over_load(&overload);
+  inv.set_warning_power_limit(&power_limit);
+  inv.set_warning_pv1_voltage_high(&pv1_high);
+  inv.set_warning_pv2_voltage_high(&pv2_high);
+  inv.set_warning_mppt1_overload(&mppt1_ovld);
+  inv.set_warning_mppt2_overload(&mppt2_ovld);
+  inv.set_warning_scc1_battery_too_low_to_charge(&scc1_low);
+  inv.set_warning_scc2_battery_too_low_to_charge(&scc2_low);
+  inv.handle_p005fws_(LV5048_P005FWS_EEPROM_WARN);
+  EXPECT_FALSE(line_fail.state);
+  EXPECT_FALSE(output_short.state);
+  EXPECT_FALSE(over_temp.state);
+  EXPECT_FALSE(fan_lock.state);
+  EXPECT_FALSE(bat_high.state);
+  EXPECT_FALSE(bat_low.state);
+  EXPECT_FALSE(bat_shutdown.state);
+  EXPECT_FALSE(overload.state);
+  EXPECT_FALSE(power_limit.state);
+  EXPECT_FALSE(pv1_high.state);
+  EXPECT_FALSE(pv2_high.state);
+  EXPECT_FALSE(mppt1_ovld.state);
+  EXPECT_FALSE(mppt2_ovld.state);
+  EXPECT_FALSE(scc1_low.state);
+  EXPECT_FALSE(scc2_low.state);
+}
+
+TEST(Pi18Lv5048Test, P005fwsMultiFaultNonZeroFaultCode) {
+  TestablePipsolar inv;
+  sensor::Sensor fault_code;
+  inv.set_fault_code(&fault_code);
+  inv.handle_p005fws_(LV5048_P005FWS_MULTI_FAULT);
+  EXPECT_FLOAT_EQ(fault_code.state, 5.0f);
+}
+
+TEST(Pi18Lv5048Test, P005fwsMultiFaultWarningsTrue) {
+  TestablePipsolar inv;
+  binary_sensor::BinarySensor line_fail, output_short, over_temp, fan_lock, bat_high;
+  binary_sensor::BinarySensor bat_low, bat_shutdown, overload;
+  inv.set_warning_line_fail(&line_fail);
+  inv.set_warning_output_circuit_short(&output_short);
+  inv.set_warning_over_temperature(&over_temp);
+  inv.set_warning_fan_lock(&fan_lock);
+  inv.set_warning_battery_voltage_high(&bat_high);
+  inv.set_warning_battery_low_alarm(&bat_low);
+  inv.set_warning_battery_under_shutdown(&bat_shutdown);
+  inv.set_warning_over_load(&overload);
+  inv.handle_p005fws_(LV5048_P005FWS_MULTI_FAULT);
+  EXPECT_TRUE(line_fail.state);
+  EXPECT_TRUE(output_short.state);
+  EXPECT_TRUE(over_temp.state);
+  EXPECT_TRUE(fan_lock.state);
+  EXPECT_TRUE(bat_high.state);
+  EXPECT_FALSE(bat_low.state);
+  EXPECT_FALSE(bat_shutdown.state);
+  EXPECT_FALSE(overload.state);
+}
+
+// ── P005ET ────────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P005etBeckoPopovTotalEnergy) {
+  TestablePipsolar inv;
+  sensor::Sensor energy;
+  inv.set_total_generated_energy(&energy);
+  inv.handle_p005et_(LV5048_P005ET_BECKOPOPOV);
+  EXPECT_FLOAT_EQ(energy.state, 802946.0f);
+}
+
+TEST(Pi18Lv5048Test, P005etBanannaJoeTotalEnergy) {
+  TestablePipsolar inv;
+  sensor::Sensor energy;
+  inv.set_total_generated_energy(&energy);
+  inv.handle_p005et_(LV5048_P005ET_BANANNAJOE);
+  EXPECT_FLOAT_EQ(energy.state, 320400.0f);
+}
+
+// ── P007PGS0 ──────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, P007pgs0TotalApparentAndActivePower) {
+  TestablePipsolar inv;
+  sensor::Sensor apparent, active;
+  inv.set_total_ac_output_apparent_power(&apparent);
+  inv.set_total_ac_output_active_power(&active);
+  inv.handle_p007pgs0_(LV5048_P007PGS0_ACTIVE);
+  EXPECT_FLOAT_EQ(apparent.state, 12338.0f);
+  EXPECT_FLOAT_EQ(active.state, 12336.0f);
+}
+
+TEST(Pi18Lv5048Test, P007pgs0TotalLoadAndChargingCurrent) {
+  TestablePipsolar inv;
+  sensor::Sensor load_pct, chg_a;
+  inv.set_total_output_load_percent(&load_pct);
+  inv.set_total_battery_charging_current(&chg_a);
+  inv.handle_p007pgs0_(LV5048_P007PGS0_ACTIVE);
+  EXPECT_FLOAT_EQ(load_pct.state, 0.0f);
+  EXPECT_FLOAT_EQ(chg_a.state, 337.0f);
+}
+
+// ── Robustness ────────────────────────────────────────────────────────────────
+
+TEST(Pi18Lv5048Test, NullSensorsDoNotCrash) {
+  TestablePipsolar inv;
+  inv.handle_p005gs_(LV5048_P005GS_STANDBY_PV);
+  inv.handle_p007piri_(LV5048_P007PIRI_BANANNAJOE);
+  inv.handle_p006mod_(LV5048_P006MOD_HYBRID);
+  inv.handle_p007flag_(LV5048_P007FLAG);
+  inv.handle_p005fws_(LV5048_P005FWS_EEPROM_WARN);
+  inv.handle_p005fws_(LV5048_P005FWS_MULTI_FAULT);
+  inv.handle_p005et_(LV5048_P005ET_BANANNAJOE);
+  inv.handle_p007pgs0_(LV5048_P007PGS0_ACTIVE);
+}
+
+TEST(Pi18Lv5048Test, EmptyMessageDoesNotCrash) {
+  TestablePipsolar inv;
+  sensor::Sensor grid_v;
+  inv.set_grid_voltage(&grid_v);
+  inv.handle_p005gs_("");
+  inv.handle_p007piri_("");
+  inv.handle_p006mod_("");
+  inv.handle_p007flag_("");
+  inv.handle_p005fws_("");
+  inv.handle_p005et_("");
+  inv.handle_p007pgs0_("");
+}
+
+}  // namespace esphome::pi18::testing

--- a/tests/components/pi18/test.host.yaml
+++ b/tests/components/pi18/test.host.yaml
@@ -1,0 +1,8 @@
+uart:
+  - id: uart_bus
+    baud_rate: 2400
+
+pi18:
+  id: pipsolar_device
+  uart_id: uart_bus
+  update_interval: 10s

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -120,3 +120,151 @@ class TestBinarySensorTypes:
 
     def test_binary_sensor_values_unique(self):
         assert len(binary_sensor.TYPES) == len(set(binary_sensor.TYPES))
+
+
+# ── pi18 component ────────────────────────────────────────────────────────────
+
+from components.pi18 import (  # noqa: E402
+    binary_sensor as pi18_bs,
+    sensor as pi18_sensor,
+    text_sensor as pi18_ts,  # noqa: E402
+)
+
+
+class TestPi18SensorTypes:
+    def test_p005gs_sensors_present(self):
+        assert pi18_sensor.CONF_GRID_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_GRID_FREQUENCY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_FREQUENCY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_APPARENT_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_ACTIVE_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_OUTPUT_LOAD_PERCENT in pi18_sensor.TYPES
+        assert "battery_voltage" in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_VOLTAGE_SCC in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_VOLTAGE_SCC2 in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_DISCHARGE_CURRENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_CHARGING_CURRENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_CAPACITY_PERCENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_INVERTER_HEAT_SINK_TEMPERATURE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_MPPT1_CHARGER_TEMPERATURE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_MPPT2_CHARGER_TEMPERATURE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_PV1_INPUT_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_PV2_INPUT_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_PV1_INPUT_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_PV2_INPUT_VOLTAGE in pi18_sensor.TYPES
+
+    def test_p007piri_sensors_present(self):
+        assert pi18_sensor.CONF_GRID_RATING_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_GRID_RATING_CURRENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_RATING_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_RATING_FREQUENCY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_RATING_CURRENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_RATING_APPARENT_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_AC_OUTPUT_RATING_ACTIVE_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_RATING_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_RECHARGE_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_REDISCHARGE_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_UNDER_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_BULK_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_FLOAT_VOLTAGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_BATTERY_TYPE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_CURRENT_MAX_AC_CHARGING_CURRENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_CURRENT_MAX_CHARGING_CURRENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_INPUT_VOLTAGE_RANGE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_OUTPUT_SOURCE_PRIORITY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_CHARGER_SOURCE_PRIORITY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_PARALLEL_MAX_NUM in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_MACHINE_TYPE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_TOPOLOGY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_OUTPUT_MODE in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_SOLAR_POWER_PRIORITY in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_MPPT_STRING in pi18_sensor.TYPES
+
+    def test_p005fws_sensor_present(self):
+        assert pi18_sensor.CONF_FAULT_CODE in pi18_sensor.TYPES
+
+    def test_p005et_sensor_present(self):
+        assert pi18_sensor.CONF_TOTAL_GENERATED_ENERGY in pi18_sensor.TYPES
+
+    def test_p006mod_sensor_present(self):
+        assert pi18_sensor.CONF_DEVICE_MODE_ID in pi18_sensor.TYPES
+
+    def test_p007pgs0_sensors_present(self):
+        assert pi18_sensor.CONF_TOTAL_AC_OUTPUT_APPARENT_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_TOTAL_AC_OUTPUT_ACTIVE_POWER in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_TOTAL_OUTPUT_LOAD_PERCENT in pi18_sensor.TYPES
+        assert pi18_sensor.CONF_TOTAL_BATTERY_CHARGING_CURRENT in pi18_sensor.TYPES
+
+    def test_sensor_types_count(self):
+        assert len(pi18_sensor.TYPES) == 52
+
+    def test_sensor_keys_unique(self):
+        assert len(pi18_sensor.TYPES) == len(set(pi18_sensor.TYPES))
+
+
+class TestPi18BinarySensorTypes:
+    def test_p005gs_binary_sensors_present(self):
+        assert pi18_bs.CONF_SETTING_VALUE_CONFIGURATION_STATE in pi18_bs.TYPES
+
+    def test_p007flag_binary_sensors_present(self):
+        assert pi18_bs.CONF_SILENCE_BUZZER_OPEN_BUZZER in pi18_bs.TYPES
+        assert pi18_bs.CONF_OVERLOAD_BYPASS_FUNCTION in pi18_bs.TYPES
+        assert pi18_bs.CONF_LCD_ESCAPE_TO_DEFAULT in pi18_bs.TYPES
+        assert pi18_bs.CONF_OVERLOAD_RESTART_FUNCTION in pi18_bs.TYPES
+        assert pi18_bs.CONF_OVER_TEMPERATURE_RESTART_FUNCTION in pi18_bs.TYPES
+        assert pi18_bs.CONF_BACKLIGHT_ON in pi18_bs.TYPES
+        assert pi18_bs.CONF_ALARM_ON_WHEN_PRIMARY_SOURCE_INTERRUPT in pi18_bs.TYPES
+        assert pi18_bs.CONF_FAULT_CODE_RECORD in pi18_bs.TYPES
+        assert pi18_bs.CONF_POWER_SAVING in pi18_bs.TYPES
+
+    def test_p005fws_binary_sensors_present(self):
+        assert pi18_bs.CONF_WARNING_LINE_FAIL in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_OUTPUT_CIRCUIT_SHORT in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_OVER_TEMPERATURE in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_FAN_LOCK in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_BATTERY_VOLTAGE_HIGH in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_BATTERY_LOW_ALARM in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_BATTERY_UNDER_SHUTDOWN in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_OVER_LOAD in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_EEPROM_FAILED in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_POWER_LIMIT in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_PV1_VOLTAGE_HIGH in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_PV2_VOLTAGE_HIGH in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_MPPT1_OVERLOAD in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_MPPT2_OVERLOAD in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_SCC1_BATTERY_TOO_LOW_TO_CHARGE in pi18_bs.TYPES
+        assert pi18_bs.CONF_WARNING_SCC2_BATTERY_TOO_LOW_TO_CHARGE in pi18_bs.TYPES
+
+    def test_binary_sensor_types_count(self):
+        assert len(pi18_bs.TYPES) == 26
+
+    def test_binary_sensor_values_unique(self):
+        assert len(pi18_bs.TYPES) == len(set(pi18_bs.TYPES))
+
+
+class TestPi18TextSensorTypes:
+    def test_p005gs_text_sensors_present(self):
+        assert pi18_ts.CONF_MPPT1_CHARGER_STATUS in pi18_ts.TYPES
+        assert pi18_ts.CONF_MPPT2_CHARGER_STATUS in pi18_ts.TYPES
+        assert pi18_ts.CONF_LOAD_CONNECTION in pi18_ts.TYPES
+        assert pi18_ts.CONF_BATTERY_POWER_DIRECTION in pi18_ts.TYPES
+        assert pi18_ts.CONF_DC_AC_POWER_DIRECTION in pi18_ts.TYPES
+        assert pi18_ts.CONF_LINE_POWER_DIRECTION in pi18_ts.TYPES
+
+    def test_p006mod_text_sensor_present(self):
+        assert pi18_ts.CONF_DEVICE_MODE in pi18_ts.TYPES
+
+    def test_raw_response_text_sensors_present(self):
+        assert pi18_ts.CONF_LAST_P005GS in pi18_ts.TYPES
+        assert pi18_ts.CONF_LAST_P007PIRI in pi18_ts.TYPES
+        assert pi18_ts.CONF_LAST_P006MOD in pi18_ts.TYPES
+        assert pi18_ts.CONF_LAST_P007FLAG in pi18_ts.TYPES
+        assert pi18_ts.CONF_LAST_P005FWS in pi18_ts.TYPES
+        assert pi18_ts.CONF_LAST_P005ET in pi18_ts.TYPES
+
+    def test_text_sensor_types_count(self):
+        assert len(pi18_ts.TYPES) == 13
+
+    def test_text_sensor_values_unique(self):
+        assert len(pi18_ts.TYPES) == len(set(pi18_ts.TYPES))


### PR DESCRIPTION
## Summary

- Adds a new `pi18` component for inverters using the PI18 protocol (LV5048, compatible MppSolar units)
- PI18 uses `^P<len><cmd>` queries and `^D<len><data><CRC><CR>` responses — distinct from the Q-command protocol used by pip8048/pip2424mse1
- Users now have a choice between three components for different protocol variants: **pip8048**, **pip2424mse1**, and **pi18**

## Supported commands

| Command | Description |
|---------|-------------|
| `^P005GS` | General status (voltages, currents, temperatures, PV power, MPPT status) |
| `^P007PIRI` | Rated information (grid/output ratings, battery settings, source priorities) |
| `^P006MOD` | Device mode |
| `^P007FLAG` | Enabled/disabled flags |
| `^P005FWS` | Fault/warning status (fault code + 17 individual warning flags) |
| `^P005ET` | Total generated energy |

## Entities

- **47 sensors** (voltages, currents, power, temperature, capacity, energy)
- **26 binary sensors** (configuration state, 9 flags, 16 warning flags)
- **13 text sensors** (MPPT/load/power direction status strings + 6 raw response captures)
- **8 select entities** (output source priority, charger source priority, solar power priority, voltage range, machine type, max charging currents, battery under voltage)
- **14 switch entities** (source priority toggles + 9 flag switches)

## Test coverage

C++ unit tests (`tests/components/pi18/pi18_lv5048_test.cpp`) use real PI18 frames recorded from LV5048 inverters (from issue #54, contributed by BanannaJoe and BeckoPopov). 22 test cases cover all six polling commands including boundary conditions and null-sensor robustness.

Python schema tests (`tests/test_component_schemas.py`) verify all 47 sensors, 26 binary sensors, and 13 text sensors are registered in their respective `TYPES` dicts.

CI is updated to compile the host test config and run C++ unit tests for the pi18 component alongside pip8048 and pip2424mse1.

## References

- Original PR: https://github.com/syssi/esphome-pipsolar/pull/128
- Real PI18 frames: https://github.com/syssi/esphome-pipsolar/issues/54