### PR TITLE
Add fake inverter YAML fixtures for pip8048, pip2424mse1, and pi18

### DIFF
--- a/tests/esp8266-fake-inverter-pi18.yaml
+++ b/tests/esp8266-fake-inverter-pi18.yaml
@@ -1,0 +1,158 @@
+# Fake pi18 inverter — simulates real inverter responses over UART.
+#
+# Responses extracted from docs/pdus/pi18/lv5048.txt (BanannaJoe's LV5048 Hybrid V2).
+#
+# PI18 protocol: queries use ^P<len><cmd>+CRC16+CR, responses use ^D<len><data>+CRC16+CR.
+#
+# Wiring (crossover):
+#   fake-inverter TX (GPIO4) → pi18 device RX
+#   fake-inverter RX (GPIO5) ← pi18 device TX
+#   GND ←→ GND
+
+substitutions:
+  name: fake-inverter-pi18
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+esphome:
+  name: ${name}
+
+esp8266:
+  board: d1_mini
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  level: DEBUG
+
+api:
+  reboot_timeout: 0s
+
+globals:
+  - id: pending_cmd
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+uart:
+  id: uart_0
+  baud_rate: 2400
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+  debug:
+    direction: RX
+    dummy_receiver: true
+    after:
+      delimiter: "\r"
+    sequence:
+      - lambda: |-
+          UARTDebug::log_string(direction, bytes);
+
+          // All PI18 queries start with 0x5E 0x50 (= ^P).
+          // Differentiate by bytes[4] (last length digit) and bytes[5..6] (cmd prefix).
+          id(pending_cmd) = 0;
+          if (bytes.size() >= 8 &&
+              bytes[0] == 0x5E && bytes[1] == 0x50) {
+            uint8_t len_digit = bytes[4];
+            uint8_t cmd0     = (bytes.size() > 5) ? bytes[5] : 0;
+            uint8_t cmd1     = (bytes.size() > 6) ? bytes[6] : 0;
+            if (len_digit == 0x35) {           // "005"
+              if      (cmd0 == 0x47)           id(pending_cmd) = 1;  // ^P005GS
+              else if (cmd0 == 0x46)           id(pending_cmd) = 5;  // ^P005FWS
+              else if (cmd0 == 0x45)           id(pending_cmd) = 6;  // ^P005ET
+            } else if (len_digit == 0x36) {    // "006"
+              /* only ^P006MOD */               id(pending_cmd) = 3;  // ^P006MOD
+            } else if (len_digit == 0x37) {    // "007"
+              if (cmd0 == 0x50) {              // P…
+                if      (cmd1 == 0x49)         id(pending_cmd) = 2;  // ^P007PIRI
+                else if (cmd1 == 0x47)         id(pending_cmd) = 7;  // ^P007PGS0
+              } else if (cmd0 == 0x46)         id(pending_cmd) = 4;  // ^P007FLAG
+            }
+          }
+      - delay: 150ms
+      - lambda: |-
+          // ^P005GS — general status: grid=231.2V/50.0Hz standby, bat=51.8V/36%/4A charging, pv1=243.8V/302W
+          static const uint8_t resp_p005gs[] = {
+            0x5E, 0x44, 0x31, 0x30, 0x36, 0x32, 0x33, 0x31, 0x32, 0x2C, 0x35, 0x30, 0x30, 0x2C, 0x30,
+            0x30, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x30, 0x30, 0x2C, 0x30, 0x30,
+            0x30, 0x30, 0x2C, 0x30, 0x30, 0x30, 0x2C, 0x35, 0x31, 0x38, 0x2C, 0x30, 0x30, 0x30, 0x2C,
+            0x30, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x34, 0x2C, 0x30, 0x33, 0x36,
+            0x2C, 0x30, 0x32, 0x37, 0x2C, 0x30, 0x30, 0x30, 0x2C, 0x30, 0x30, 0x30, 0x2C, 0x30, 0x33,
+            0x30, 0x32, 0x2C, 0x30, 0x30, 0x30, 0x30, 0x2C, 0x32, 0x34, 0x33, 0x38, 0x2C, 0x30, 0x30,
+            0x30, 0x30, 0x2C, 0x30, 0x2C, 0x32, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x31, 0x2C, 0x32, 0x2C,
+            0x32, 0x2C, 0x30, 0xDC, 0x8E, 0x0D,
+          };
+          // ^P007PIRI — device ratings: 230V/5600VA, 48V bat, bulk=55.4V float=54.0V, 60A max charge
+          static const uint8_t resp_p007piri[] = {
+            0x5E, 0x44, 0x30, 0x38, 0x39, 0x32, 0x33, 0x30, 0x30, 0x2C, 0x32, 0x34, 0x33, 0x2C, 0x32,
+            0x33, 0x30, 0x30, 0x2C, 0x35, 0x30, 0x30, 0x2C, 0x32, 0x34, 0x33, 0x2C, 0x35, 0x36, 0x30,
+            0x30, 0x2C, 0x35, 0x36, 0x30, 0x30, 0x2C, 0x34, 0x38, 0x30, 0x2C, 0x35, 0x30, 0x30, 0x2C,
+            0x35, 0x32, 0x30, 0x2C, 0x34, 0x38, 0x30, 0x2C, 0x35, 0x35, 0x34, 0x2C, 0x35, 0x34, 0x30,
+            0x2C, 0x32, 0x2C, 0x30, 0x31, 0x30, 0x2C, 0x30, 0x36, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C,
+            0x32, 0x2C, 0x39, 0x2C, 0x31, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x31, 0x2C, 0x30,
+            0x30, 0xD6, 0x78, 0x0D,
+          };
+          // ^P006MOD — device mode: 5 (hybrid)
+          static const uint8_t resp_p006mod[] = {
+            0x5E, 0x44, 0x30, 0x30, 0x35, 0x30, 0x35, 0xD9, 0x9F, 0x0D,
+          };
+          // ^P007FLAG — flags: silence=1,bypass=1,lcd=1,ovl_restart=0,temp_restart=0,backlight=1,alarm=0,fault_rec=1,save=0
+          static const uint8_t resp_p007flag[] = {
+            0x5E, 0x44, 0x30, 0x32, 0x30, 0x31, 0x2C, 0x31, 0x2C, 0x31, 0x2C, 0x30, 0x2C, 0x30, 0x2C,
+            0x31, 0x2C, 0x30, 0x2C, 0x31, 0x2C, 0x30, 0xF6, 0x3D, 0x0D,
+          };
+          // ^P005FWS — fault/warning status: no faults, eeprom warning only
+          static const uint8_t resp_p005fws[] = {
+            0x5E, 0x44, 0x30, 0x33, 0x39, 0x30, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30,
+            0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x31, 0x2C, 0x30, 0x2C, 0x30, 0x2C,
+            0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0x2C, 0x30, 0xA6, 0x7C, 0x0D,
+          };
+          // ^P005ET — total energy: 320400 kWh
+          static const uint8_t resp_p005et[] = {
+            0x5E, 0x44, 0x30, 0x31, 0x31, 0x30, 0x30, 0x33, 0x32, 0x30, 0x34, 0x30, 0x30, 0x8A, 0x63,
+            0x0D,
+          };
+          // NAK — for unsupported commands (^P007PGS0 on a standalone unit)
+          static const uint8_t resp_nak[] = {
+            0x28, 0x4E, 0x41, 0x4B, 0x73, 0x73, 0x0D,
+          };
+
+          switch (id(pending_cmd)) {
+            case 1:
+              ESP_LOGD("fake_inv", "Responding to ^P005GS (%d bytes)", sizeof(resp_p005gs));
+              id(uart_0).write_array(resp_p005gs, sizeof(resp_p005gs));
+              break;
+            case 2:
+              ESP_LOGD("fake_inv", "Responding to ^P007PIRI (%d bytes)", sizeof(resp_p007piri));
+              id(uart_0).write_array(resp_p007piri, sizeof(resp_p007piri));
+              break;
+            case 3:
+              ESP_LOGD("fake_inv", "Responding to ^P006MOD (%d bytes)", sizeof(resp_p006mod));
+              id(uart_0).write_array(resp_p006mod, sizeof(resp_p006mod));
+              break;
+            case 4:
+              ESP_LOGD("fake_inv", "Responding to ^P007FLAG (%d bytes)", sizeof(resp_p007flag));
+              id(uart_0).write_array(resp_p007flag, sizeof(resp_p007flag));
+              break;
+            case 5:
+              ESP_LOGD("fake_inv", "Responding to ^P005FWS (%d bytes)", sizeof(resp_p005fws));
+              id(uart_0).write_array(resp_p005fws, sizeof(resp_p005fws));
+              break;
+            case 6:
+              ESP_LOGD("fake_inv", "Responding to ^P005ET (%d bytes)", sizeof(resp_p005et));
+              id(uart_0).write_array(resp_p005et, sizeof(resp_p005et));
+              break;
+            case 7:
+              ESP_LOGD("fake_inv", "Responding to ^P007PGS0 with NAK (standalone unit)");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            default:
+              ESP_LOGW("fake_inv", "Unknown command (pending_cmd=%d), no response", id(pending_cmd));
+              break;
+          }
+          id(pending_cmd) = 0;

--- a/tests/esp8266-fake-inverter-pi18.yaml
+++ b/tests/esp8266-fake-inverter-pi18.yaml
@@ -5,8 +5,8 @@
 # PI18 protocol: queries use ^P<len><cmd>+CRC16+CR, responses use ^D<len><data>+CRC16+CR.
 #
 # Wiring (crossover):
-#   fake-inverter TX (GPIO4) → pi18 device RX
-#   fake-inverter RX (GPIO5) ← pi18 device TX
+#   fake-inverter TX (GPIO4) → pi18 RX
+#   fake-inverter RX (GPIO5) ← pi18 TX
 #   GND ←→ GND
 
 substitutions:

--- a/tests/esp8266-fake-inverter-pip2424mse1.yaml
+++ b/tests/esp8266-fake-inverter-pip2424mse1.yaml
@@ -1,0 +1,148 @@
+# Fake pip2424mse1 inverter — simulates real inverter responses over UART.
+#
+# Responses extracted from docs/pdus/pip2424mse1/easun-5500w-1ph.txt (EASUN 5.5 kW, Cycle 2).
+# Cycle 1 QPIGS response has a corrupt CRC and was skipped.
+#
+# Wiring (crossover):
+#   fake-inverter TX (GPIO4) → pip2424mse1 device RX
+#   fake-inverter RX (GPIO5) ← pip2424mse1 device TX
+#   GND ←→ GND
+
+substitutions:
+  name: fake-inverter-pip2424mse1
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+esphome:
+  name: ${name}
+
+esp8266:
+  board: d1_mini
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  level: DEBUG
+
+api:
+  reboot_timeout: 0s
+
+globals:
+  - id: pending_cmd
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+uart:
+  id: uart_0
+  baud_rate: 2400
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+  debug:
+    direction: RX
+    dummy_receiver: true
+    after:
+      delimiter: "\r"
+    sequence:
+      - lambda: |-
+          UARTDebug::log_string(direction, bytes);
+
+          // All queries start with 0x51 ('Q').
+          // QPIGS/QPIRI/QPIWS share prefix 51:50:49 — differentiate via bytes[3].
+          // QMOD/QMN share prefix 51:4D — differentiate via bytes[2].
+          id(pending_cmd) = 0;
+          if (bytes.size() >= 3 && bytes[0] == 0x51) {
+            if (bytes[1] == 0x50 && bytes[2] == 0x49 && bytes.size() >= 6) {
+              if      (bytes[3] == 0x47) id(pending_cmd) = 1;  // QPIGS
+              else if (bytes[3] == 0x52) id(pending_cmd) = 2;  // QPIRI
+              else if (bytes[3] == 0x57) id(pending_cmd) = 5;  // QPIWS
+            } else if (bytes[1] == 0x4D) {
+              if      (bytes[2] == 0x4F) id(pending_cmd) = 3;  // QMOD
+              else if (bytes[2] == 0x4E) id(pending_cmd) = 7;  // QMN
+            } else if (bytes[1] == 0x46 && bytes.size() >= 7) {
+                                         id(pending_cmd) = 4;  // QFLAG
+            } else if (bytes[1] == 0x54) {
+                                         id(pending_cmd) = 6;  // QT
+            } else if (bytes[1] == 0x42 && bytes.size() >= 8) {
+                                         id(pending_cmd) = 8;  // QBATCD
+            }
+          }
+      - delay: 150ms
+      - lambda: |-
+          // QPIGS (Cycle 2): grid=238.3V/50.0Hz, output=230.2V/0322VA/0205W, bat=42.2V/050%, pv=224.7V/00473W
+          static const uint8_t resp_qpigs[] = {
+            0x28, 0x32, 0x33, 0x38, 0x2E, 0x33, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x32, 0x33, 0x30,
+            0x2E, 0x32, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x30, 0x33, 0x32, 0x32, 0x20, 0x30, 0x32,
+            0x30, 0x35, 0x20, 0x30, 0x30, 0x35, 0x20, 0x34, 0x32, 0x32, 0x20, 0x35, 0x33, 0x2E, 0x32,
+            0x30, 0x20, 0x30, 0x30, 0x30, 0x20, 0x30, 0x35, 0x30, 0x20, 0x30, 0x30, 0x35, 0x36, 0x20,
+            0x30, 0x32, 0x2E, 0x31, 0x20, 0x32, 0x32, 0x34, 0x2E, 0x37, 0x20, 0x30, 0x30, 0x2E, 0x30,
+            0x30, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x31, 0x30, 0x31, 0x31,
+            0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x34, 0x37, 0x33, 0x20, 0x30,
+            0x31, 0x30, 0xA9, 0x79, 0x0D,
+          };
+          // QPIRI: 230V/23.9A rated, 48V bat, bulk=55.3V float=55.3V, 60A max charge, solar-first
+          static const uint8_t resp_qpiri[] = {
+            0x28, 0x32, 0x33, 0x30, 0x2E, 0x30, 0x20, 0x32, 0x33, 0x2E, 0x39, 0x20, 0x32, 0x33, 0x30,
+            0x2E, 0x30, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x32, 0x33, 0x2E, 0x39, 0x20, 0x35, 0x35,
+            0x30, 0x30, 0x20, 0x35, 0x35, 0x30, 0x30, 0x20, 0x34, 0x38, 0x2E, 0x30, 0x20, 0x35, 0x31,
+            0x2E, 0x30, 0x20, 0x34, 0x38, 0x2E, 0x30, 0x20, 0x35, 0x35, 0x2E, 0x33, 0x20, 0x35, 0x35,
+            0x2E, 0x33, 0x20, 0x32, 0x20, 0x30, 0x32, 0x20, 0x31, 0x30, 0x30, 0x20, 0x30, 0x20, 0x32,
+            0x20, 0x33, 0x20, 0x31, 0x20, 0x30, 0x31, 0x20, 0x30, 0x20, 0x30, 0x20, 0x35, 0x33, 0x2E,
+            0x30, 0x20, 0x30, 0x20, 0x31, 0x0E, 0x3E, 0x0D,
+          };
+          // QMOD: B (battery mode)
+          static const uint8_t resp_qmod[] = {
+            0x28, 0x42, 0xE7, 0xC9, 0x0D,
+          };
+          // QFLAG: EzDabjkuvxy
+          static const uint8_t resp_qflag[] = {
+            0x28, 0x45, 0x7A, 0x44, 0x61, 0x62, 0x6A, 0x6B, 0x75, 0x76, 0x78, 0x79, 0xFF, 0xD8, 0x0D,
+          };
+          // NAK — for QPIWS, QT, QMN, QBATCD (not present in EASUN trace)
+          static const uint8_t resp_nak[] = {
+            0x28, 0x4E, 0x41, 0x4B, 0x73, 0x73, 0x0D,
+          };
+
+          switch (id(pending_cmd)) {
+            case 1:
+              ESP_LOGD("fake_inv", "Responding to QPIGS (%d bytes)", sizeof(resp_qpigs));
+              id(uart_0).write_array(resp_qpigs, sizeof(resp_qpigs));
+              break;
+            case 2:
+              ESP_LOGD("fake_inv", "Responding to QPIRI (%d bytes)", sizeof(resp_qpiri));
+              id(uart_0).write_array(resp_qpiri, sizeof(resp_qpiri));
+              break;
+            case 3:
+              ESP_LOGD("fake_inv", "Responding to QMOD (%d bytes)", sizeof(resp_qmod));
+              id(uart_0).write_array(resp_qmod, sizeof(resp_qmod));
+              break;
+            case 4:
+              ESP_LOGD("fake_inv", "Responding to QFLAG (%d bytes)", sizeof(resp_qflag));
+              id(uart_0).write_array(resp_qflag, sizeof(resp_qflag));
+              break;
+            case 5:
+              ESP_LOGD("fake_inv", "Responding to QPIWS with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            case 6:
+              ESP_LOGD("fake_inv", "Responding to QT with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            case 7:
+              ESP_LOGD("fake_inv", "Responding to QMN with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            case 8:
+              ESP_LOGD("fake_inv", "Responding to QBATCD with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            default:
+              ESP_LOGW("fake_inv", "Unknown command (pending_cmd=%d), no response", id(pending_cmd));
+              break;
+          }
+          id(pending_cmd) = 0;

--- a/tests/esp8266-fake-inverter-pip2424mse1.yaml
+++ b/tests/esp8266-fake-inverter-pip2424mse1.yaml
@@ -4,8 +4,8 @@
 # Cycle 1 QPIGS response has a corrupt CRC and was skipped.
 #
 # Wiring (crossover):
-#   fake-inverter TX (GPIO4) → pip2424mse1 device RX
-#   fake-inverter RX (GPIO5) ← pip2424mse1 device TX
+#   fake-inverter TX (GPIO4) → pip2424mse1 RX
+#   fake-inverter RX (GPIO5) ← pip2424mse1 TX
 #   GND ←→ GND
 
 substitutions:

--- a/tests/esp8266-fake-inverter-pip8048.yaml
+++ b/tests/esp8266-fake-inverter-pip8048.yaml
@@ -1,17 +1,17 @@
-# Fake pip8048 (PI30 protocol) inverter — simulates real inverter responses over UART.
+# Fake pip8048 inverter — simulates real inverter responses over UART.
+#
+# Responses extracted from pipsolar-working-esphome-2025.12.7.txt (jopl's inverter).
 #
 # Purpose: Reproduce the ESPHome 2026.3.x stale-FIFO bug without a physical inverter.
-#   At boot this device immediately sends a QMOD response so the pipsolar device
+#   At boot this device immediately sends a QMOD response so the pip8048 component
 #   finds stale bytes in its hardware UART FIFO on startup. With ESPHome ≥ 2026.3.x
 #   empty_uart_buffer_() fails to drain them because available() returns 0 for
 #   hardware-FIFO bytes that haven't been moved to the software ring buffer yet.
 #
 # Wiring (crossover):
-#   fake-inverter TX (GPIO4) → pipsolar RX
-#   fake-inverter RX (GPIO5) ← pipsolar TX
+#   fake-inverter TX (GPIO4) → pip8048 RX
+#   fake-inverter RX (GPIO5) ← pip8048 TX
 #   GND ←→ GND
-#
-# Responses extracted from pipsolar-working-esphome-2025.12.7.txt (jopl's inverter).
 
 substitutions:
   name: fake-inverter-pip8048
@@ -21,8 +21,8 @@ substitutions:
 esphome:
   name: ${name}
   on_boot:
-    # Run at hardware-init priority so bytes arrive in pipsolar's FIFO before
-    # pipsolar's setup() calls empty_uart_buffer_().
+    # Run at hardware-init priority so bytes arrive in pip8048's FIFO before
+    # pip8048's setup() calls empty_uart_buffer_().
     priority: 800.0
     then:
       - logger.log:
@@ -68,46 +68,29 @@ uart:
       - lambda: |-
           UARTDebug::log_string(direction, bytes);
 
-          // Detect command from pipsolar (check QPIGS2 before QPIGS — same prefix)
-          if (bytes.size() >= 6 &&
-              bytes[0]==0x51 && bytes[1]==0x42 && bytes[2]==0x41 &&
-              bytes[3]==0x54 && bytes[4]==0x43 && bytes[5]==0x44) {
-            id(pending_cmd) = 6;  // QBATCD
-          } else if (bytes.size() >= 6 &&
-              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
-              bytes[3]==0x47 && bytes[4]==0x53 && bytes[5]==0x32) {
-            id(pending_cmd) = 2;  // QPIGS2
-          } else if (bytes.size() >= 5 &&
-              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
-              bytes[3]==0x47 && bytes[4]==0x53) {
-            id(pending_cmd) = 1;  // QPIGS
-          } else if (bytes.size() >= 5 &&
-              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
-              bytes[3]==0x52 && bytes[4]==0x49) {
-            id(pending_cmd) = 3;  // QPIRI
-          } else if (bytes.size() >= 4 &&
-              bytes[0]==0x51 && bytes[1]==0x4D && bytes[2]==0x4F && bytes[3]==0x44) {
-            id(pending_cmd) = 4;  // QMOD
-          } else if (bytes.size() >= 5 &&
-              bytes[0]==0x51 && bytes[1]==0x46 && bytes[2]==0x4C &&
-              bytes[3]==0x41 && bytes[4]==0x47) {
-            id(pending_cmd) = 5;  // QFLAG
-          } else if (bytes.size() >= 5 &&
-              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
-              bytes[3]==0x57 && bytes[4]==0x53) {
-            id(pending_cmd) = 7;  // QPIWS
-          } else if (bytes.size() >= 3 &&
-              bytes[0]==0x51 && bytes[1]==0x4D && bytes[2]==0x4E) {
-            id(pending_cmd) = 8;  // QMN
-          } else if (bytes.size() >= 2 &&
-              bytes[0]==0x51 && bytes[1]==0x54) {
-            id(pending_cmd) = 9;  // QT
-          } else {
-            id(pending_cmd) = 0;
+          // Check QPIGS2 before QPIGS — both share bytes[0..4], QPIGS2 adds '2' (0x32) at bytes[5].
+          id(pending_cmd) = 0;
+          if (bytes.size() >= 2 && bytes[0] == 0x51) {
+            if (bytes[1] == 0x42 && bytes.size() >= 8) {
+                                               id(pending_cmd) = 6;  // QBATCD
+            } else if (bytes[1] == 0x50 && bytes.size() >= 6 && bytes[2] == 0x49) {
+              if      (bytes[3] == 0x47 && bytes.size() >= 9 && bytes[5] == 0x32)
+                                               id(pending_cmd) = 2;  // QPIGS2
+              else if (bytes[3] == 0x47)       id(pending_cmd) = 1;  // QPIGS
+              else if (bytes[3] == 0x52)       id(pending_cmd) = 3;  // QPIRI
+              else if (bytes[3] == 0x57)       id(pending_cmd) = 7;  // QPIWS
+            } else if (bytes[1] == 0x4D && bytes.size() >= 3) {
+              if      (bytes[2] == 0x4F)       id(pending_cmd) = 4;  // QMOD
+              else if (bytes[2] == 0x4E)       id(pending_cmd) = 8;  // QMN
+            } else if (bytes[1] == 0x46 && bytes.size() >= 7) {
+                                               id(pending_cmd) = 5;  // QFLAG
+            } else if (bytes[1] == 0x54) {
+                                               id(pending_cmd) = 9;  // QT
+            }
           }
       - delay: 150ms
       - lambda: |-
-          // QPIGS: (243.0 49.8 230.1 50.0 00276 00147 002 375 53.20 000 050 0032 00.8 091.5 00.00 00000 00010110 00 00 00080 010 0 00 0000-L\r
+          // QPIGS: grid=243.0V/49.8Hz, output=230.1V/276VA/147W, bat=53.20V/50%, pv=91.5V/80W
           static const uint8_t resp_qpigs[] = {
             0x28, 0x32, 0x34, 0x33, 0x2E, 0x30, 0x20, 0x34, 0x39, 0x2E, 0x38, 0x20, 0x32, 0x33, 0x30,
             0x2E, 0x31, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x30, 0x30, 0x32, 0x37, 0x36, 0x20, 0x30,
@@ -117,14 +100,14 @@ uart:
             0x2E, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x31, 0x30,
             0x31, 0x31, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x38, 0x30,
             0x20, 0x30, 0x31, 0x30, 0x20, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x30, 0x2D,
-            0x4C, 0x0D
+            0x4C, 0x0D,
           };
-          // QPIGS2: (00.8 091.9 00080 <CRC>\r
+          // QPIGS2: pv2_current=00.8A, pv2_voltage=091.9V, pv2_power=00080W
           static const uint8_t resp_qpigs2[] = {
             0x28, 0x30, 0x30, 0x2E, 0x38, 0x20, 0x30, 0x39, 0x31, 0x2E, 0x39, 0x20, 0x30, 0x30, 0x30,
-            0x38, 0x30, 0x20, 0xCB, 0xD2, 0x0D
+            0x38, 0x30, 0x20, 0xCB, 0xD2, 0x0D,
           };
-          // QPIRI: (230.0 47.8 230.0 50.0 47.8 11000 11000 48.0 50.0 48.0 56.0 55.2 2 010 100 1 2 1 9 01 0 0 52.0 0 1 480 0 000<CRC>\r
+          // QPIRI: 230V/47.8A rated, 48V bat, bulk=56.0V float=55.2V, 100A max charge, SBU priority
           static const uint8_t resp_qpiri[] = {
             0x28, 0x32, 0x33, 0x30, 0x2E, 0x30, 0x20, 0x34, 0x37, 0x2E, 0x38, 0x20, 0x32, 0x33, 0x30,
             0x2E, 0x30, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x34, 0x37, 0x2E, 0x38, 0x20, 0x31, 0x31,
@@ -133,25 +116,25 @@ uart:
             0x35, 0x35, 0x2E, 0x32, 0x20, 0x32, 0x20, 0x30, 0x31, 0x30, 0x20, 0x31, 0x30, 0x30, 0x20,
             0x31, 0x20, 0x32, 0x20, 0x31, 0x20, 0x39, 0x20, 0x30, 0x31, 0x20, 0x30, 0x20, 0x30, 0x20,
             0x35, 0x32, 0x2E, 0x30, 0x20, 0x30, 0x20, 0x31, 0x20, 0x34, 0x38, 0x30, 0x20, 0x30, 0x20,
-            0x30, 0x30, 0x30, 0xC3, 0xF1, 0x0D
+            0x30, 0x30, 0x30, 0xC3, 0xF1, 0x0D,
           };
-          // QMOD: (B<CRC>\r
+          // QMOD: B (battery mode)
           static const uint8_t resp_qmod[] = {
-            0x28, 0x42, 0xE7, 0xC9, 0x0D
+            0x28, 0x42, 0xE7, 0xC9, 0x0D,
           };
-          // QFLAG: (EkuvxyzDabdjln<CRC>\r  (CRC-OK version)
+          // QFLAG: EkuvxyzDabdjln
           static const uint8_t resp_qflag[] = {
             0x28, 0x45, 0x6B, 0x75, 0x76, 0x78, 0x79, 0x7A, 0x44, 0x61, 0x62, 0x64, 0x6A, 0x6C, 0x6E,
-            0xEE, 0xCC, 0x0D
+            0xEE, 0xCC, 0x0D,
           };
-          // QBATCD / unsupported: (NAKss\r
-          static const uint8_t resp_nak[] = {
-            0x28, 0x4E, 0x41, 0x4B, 0x73, 0x73, 0x0D
-          };
-          // QT: (20200422172244m<CRC>\r
+          // QT: 20200422172244
           static const uint8_t resp_qt[] = {
             0x28, 0x32, 0x30, 0x32, 0x30, 0x30, 0x34, 0x32, 0x32, 0x31, 0x37, 0x32, 0x32, 0x34, 0x34,
-            0x6D, 0x9C, 0x0D
+            0x6D, 0x9C, 0x0D,
+          };
+          // NAK — for QBATCD, QPIWS, QMN
+          static const uint8_t resp_nak[] = {
+            0x28, 0x4E, 0x41, 0x4B, 0x73, 0x73, 0x0D,
           };
 
           switch (id(pending_cmd)) {

--- a/tests/esp8266-fake-inverter-pip8048.yaml
+++ b/tests/esp8266-fake-inverter-pip8048.yaml
@@ -1,0 +1,198 @@
+# Fake pip8048 (PI30 protocol) inverter — simulates real inverter responses over UART.
+#
+# Purpose: Reproduce the ESPHome 2026.3.x stale-FIFO bug without a physical inverter.
+#   At boot this device immediately sends a QMOD response so the pipsolar device
+#   finds stale bytes in its hardware UART FIFO on startup. With ESPHome ≥ 2026.3.x
+#   empty_uart_buffer_() fails to drain them because available() returns 0 for
+#   hardware-FIFO bytes that haven't been moved to the software ring buffer yet.
+#
+# Wiring (crossover):
+#   fake-inverter TX (GPIO4) → pipsolar RX
+#   fake-inverter RX (GPIO5) ← pipsolar TX
+#   GND ←→ GND
+#
+# Responses extracted from pipsolar-working-esphome-2025.12.7.txt (jopl's inverter).
+
+substitutions:
+  name: fake-inverter-pip8048
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+esphome:
+  name: ${name}
+  on_boot:
+    # Run at hardware-init priority so bytes arrive in pipsolar's FIFO before
+    # pipsolar's setup() calls empty_uart_buffer_().
+    priority: 800.0
+    then:
+      - logger.log:
+          level: INFO
+          format: "Injecting stale QMOD response to simulate hardware FIFO at boot"
+      - uart.write:
+          id: uart_0
+          data: [0x28, 0x42, 0xE7, 0xC9, 0x0D]  # (B<CRC>\r — QMOD response
+
+esp8266:
+  board: d1_mini
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  level: DEBUG
+
+api:
+  reboot_timeout: 0s
+
+globals:
+  - id: pending_cmd
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+uart:
+  id: uart_0
+  baud_rate: 2400
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+  debug:
+    direction: RX
+    dummy_receiver: true
+    after:
+      delimiter: "\r"
+    sequence:
+      - lambda: |-
+          UARTDebug::log_string(direction, bytes);
+
+          // Detect command from pipsolar (check QPIGS2 before QPIGS — same prefix)
+          if (bytes.size() >= 6 &&
+              bytes[0]==0x51 && bytes[1]==0x42 && bytes[2]==0x41 &&
+              bytes[3]==0x54 && bytes[4]==0x43 && bytes[5]==0x44) {
+            id(pending_cmd) = 6;  // QBATCD
+          } else if (bytes.size() >= 6 &&
+              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
+              bytes[3]==0x47 && bytes[4]==0x53 && bytes[5]==0x32) {
+            id(pending_cmd) = 2;  // QPIGS2
+          } else if (bytes.size() >= 5 &&
+              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
+              bytes[3]==0x47 && bytes[4]==0x53) {
+            id(pending_cmd) = 1;  // QPIGS
+          } else if (bytes.size() >= 5 &&
+              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
+              bytes[3]==0x52 && bytes[4]==0x49) {
+            id(pending_cmd) = 3;  // QPIRI
+          } else if (bytes.size() >= 4 &&
+              bytes[0]==0x51 && bytes[1]==0x4D && bytes[2]==0x4F && bytes[3]==0x44) {
+            id(pending_cmd) = 4;  // QMOD
+          } else if (bytes.size() >= 5 &&
+              bytes[0]==0x51 && bytes[1]==0x46 && bytes[2]==0x4C &&
+              bytes[3]==0x41 && bytes[4]==0x47) {
+            id(pending_cmd) = 5;  // QFLAG
+          } else if (bytes.size() >= 5 &&
+              bytes[0]==0x51 && bytes[1]==0x50 && bytes[2]==0x49 &&
+              bytes[3]==0x57 && bytes[4]==0x53) {
+            id(pending_cmd) = 7;  // QPIWS
+          } else if (bytes.size() >= 3 &&
+              bytes[0]==0x51 && bytes[1]==0x4D && bytes[2]==0x4E) {
+            id(pending_cmd) = 8;  // QMN
+          } else if (bytes.size() >= 2 &&
+              bytes[0]==0x51 && bytes[1]==0x54) {
+            id(pending_cmd) = 9;  // QT
+          } else {
+            id(pending_cmd) = 0;
+          }
+      - delay: 150ms
+      - lambda: |-
+          // QPIGS: (243.0 49.8 230.1 50.0 00276 00147 002 375 53.20 000 050 0032 00.8 091.5 00.00 00000 00010110 00 00 00080 010 0 00 0000-L\r
+          static const uint8_t resp_qpigs[] = {
+            0x28, 0x32, 0x34, 0x33, 0x2E, 0x30, 0x20, 0x34, 0x39, 0x2E, 0x38, 0x20, 0x32, 0x33, 0x30,
+            0x2E, 0x31, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x30, 0x30, 0x32, 0x37, 0x36, 0x20, 0x30,
+            0x30, 0x31, 0x34, 0x37, 0x20, 0x30, 0x30, 0x32, 0x20, 0x33, 0x37, 0x35, 0x20, 0x35, 0x33,
+            0x2E, 0x32, 0x30, 0x20, 0x30, 0x30, 0x30, 0x20, 0x30, 0x35, 0x30, 0x20, 0x30, 0x30, 0x33,
+            0x32, 0x20, 0x30, 0x30, 0x2E, 0x38, 0x20, 0x30, 0x39, 0x31, 0x2E, 0x35, 0x20, 0x30, 0x30,
+            0x2E, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x31, 0x30,
+            0x31, 0x31, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x38, 0x30,
+            0x20, 0x30, 0x31, 0x30, 0x20, 0x30, 0x20, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x30, 0x2D,
+            0x4C, 0x0D
+          };
+          // QPIGS2: (00.8 091.9 00080 <CRC>\r
+          static const uint8_t resp_qpigs2[] = {
+            0x28, 0x30, 0x30, 0x2E, 0x38, 0x20, 0x30, 0x39, 0x31, 0x2E, 0x39, 0x20, 0x30, 0x30, 0x30,
+            0x38, 0x30, 0x20, 0xCB, 0xD2, 0x0D
+          };
+          // QPIRI: (230.0 47.8 230.0 50.0 47.8 11000 11000 48.0 50.0 48.0 56.0 55.2 2 010 100 1 2 1 9 01 0 0 52.0 0 1 480 0 000<CRC>\r
+          static const uint8_t resp_qpiri[] = {
+            0x28, 0x32, 0x33, 0x30, 0x2E, 0x30, 0x20, 0x34, 0x37, 0x2E, 0x38, 0x20, 0x32, 0x33, 0x30,
+            0x2E, 0x30, 0x20, 0x35, 0x30, 0x2E, 0x30, 0x20, 0x34, 0x37, 0x2E, 0x38, 0x20, 0x31, 0x31,
+            0x30, 0x30, 0x30, 0x20, 0x31, 0x31, 0x30, 0x30, 0x30, 0x20, 0x34, 0x38, 0x2E, 0x30, 0x20,
+            0x35, 0x30, 0x2E, 0x30, 0x20, 0x34, 0x38, 0x2E, 0x30, 0x20, 0x35, 0x36, 0x2E, 0x30, 0x20,
+            0x35, 0x35, 0x2E, 0x32, 0x20, 0x32, 0x20, 0x30, 0x31, 0x30, 0x20, 0x31, 0x30, 0x30, 0x20,
+            0x31, 0x20, 0x32, 0x20, 0x31, 0x20, 0x39, 0x20, 0x30, 0x31, 0x20, 0x30, 0x20, 0x30, 0x20,
+            0x35, 0x32, 0x2E, 0x30, 0x20, 0x30, 0x20, 0x31, 0x20, 0x34, 0x38, 0x30, 0x20, 0x30, 0x20,
+            0x30, 0x30, 0x30, 0xC3, 0xF1, 0x0D
+          };
+          // QMOD: (B<CRC>\r
+          static const uint8_t resp_qmod[] = {
+            0x28, 0x42, 0xE7, 0xC9, 0x0D
+          };
+          // QFLAG: (EkuvxyzDabdjln<CRC>\r  (CRC-OK version)
+          static const uint8_t resp_qflag[] = {
+            0x28, 0x45, 0x6B, 0x75, 0x76, 0x78, 0x79, 0x7A, 0x44, 0x61, 0x62, 0x64, 0x6A, 0x6C, 0x6E,
+            0xEE, 0xCC, 0x0D
+          };
+          // QBATCD / unsupported: (NAKss\r
+          static const uint8_t resp_nak[] = {
+            0x28, 0x4E, 0x41, 0x4B, 0x73, 0x73, 0x0D
+          };
+          // QT: (20200422172244m<CRC>\r
+          static const uint8_t resp_qt[] = {
+            0x28, 0x32, 0x30, 0x32, 0x30, 0x30, 0x34, 0x32, 0x32, 0x31, 0x37, 0x32, 0x32, 0x34, 0x34,
+            0x6D, 0x9C, 0x0D
+          };
+
+          switch (id(pending_cmd)) {
+            case 1:
+              ESP_LOGD("fake_inv", "Responding to QPIGS (%d bytes)", sizeof(resp_qpigs));
+              id(uart_0).write_array(resp_qpigs, sizeof(resp_qpigs));
+              break;
+            case 2:
+              ESP_LOGD("fake_inv", "Responding to QPIGS2 (%d bytes)", sizeof(resp_qpigs2));
+              id(uart_0).write_array(resp_qpigs2, sizeof(resp_qpigs2));
+              break;
+            case 3:
+              ESP_LOGD("fake_inv", "Responding to QPIRI (%d bytes)", sizeof(resp_qpiri));
+              id(uart_0).write_array(resp_qpiri, sizeof(resp_qpiri));
+              break;
+            case 4:
+              ESP_LOGD("fake_inv", "Responding to QMOD (%d bytes)", sizeof(resp_qmod));
+              id(uart_0).write_array(resp_qmod, sizeof(resp_qmod));
+              break;
+            case 5:
+              ESP_LOGD("fake_inv", "Responding to QFLAG (%d bytes)", sizeof(resp_qflag));
+              id(uart_0).write_array(resp_qflag, sizeof(resp_qflag));
+              break;
+            case 6:
+              ESP_LOGD("fake_inv", "Responding to QBATCD with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            case 7:
+              ESP_LOGD("fake_inv", "Responding to QPIWS with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            case 8:
+              ESP_LOGD("fake_inv", "Responding to QMN with NAK");
+              id(uart_0).write_array(resp_nak, sizeof(resp_nak));
+              break;
+            case 9:
+              ESP_LOGD("fake_inv", "Responding to QT (%d bytes)", sizeof(resp_qt));
+              id(uart_0).write_array(resp_qt, sizeof(resp_qt));
+              break;
+            default:
+              ESP_LOGW("fake_inv", "Unknown command (pending_cmd=%d), no response", id(pending_cmd));
+              break;
+          }
+          id(pending_cmd) = 0;


### PR DESCRIPTION
## Summary

Adds three ESP8266-based fake inverter fixtures to `tests/`, one per component/protocol. Each fixture runs on a D1 mini, listens for query frames over UART, and replies with real captured responses — enabling component testing without physical inverter hardware.

| File | Protocol | Responses from |
|------|----------|----------------|
| `esp8266-fake-inverter-pip8048.yaml` | PI30 | Voltronic Axpert Max (jopl's trace) |
| `esp8266-fake-inverter-pip2424mse1.yaml` | PI30 variant | EASUN 5.5 kW (`easun-5500w-1ph.txt`) |
| `esp8266-fake-inverter-pi18.yaml` | PI18 (`^P`/`^D`) | MppSolar LV5048 (`lv5048.txt`) |

**pip8048** handles QPIGS, QPIGS2, QPIRI, QMOD, QFLAG, QBATCD, QPIWS, QMN, QT.

**pip2424mse1** handles QPIGS, QPIRI, QMOD, QFLAG; returns NAK for QPIWS, QT, QMN, QBATCD (commands absent from the captured trace). Note: the Cycle 1 QPIGS frame in the trace has a corrupt CRC — Cycle 2 is used.

**pi18** handles ^P005GS, ^P007PIRI, ^P006MOD, ^P007FLAG, ^P005FWS, ^P005ET; returns NAK for ^P007PGS0 (standalone unit, no parallel peers).

## Wiring (same for all three)

```
fake-inverter TX (GPIO4)  →  component device RX
fake-inverter RX (GPIO5)  ←  component device TX
GND  ↔  GND
```

Flash the fake inverter first, then the component firmware. The 150 ms delay between receiving a query and sending the reply gives the component time to switch from TX to RX mode.