### PR TITLE
Fix output.pi18.set_level action registration

### DIFF
--- a/components/pi18/output/__init__.py
+++ b/components/pi18/output/__init__.py
@@ -75,14 +75,15 @@ async def to_code(config):
     SetOutputAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(CONF_ID),
+            cv.Required(CONF_ID): cv.use_id(PipsolarOutput),
             cv.Required(CONF_VALUE): cv.templatable(cv.positive_float),
         }
     ),
+    synchronous=True,
 )
 async def output_pi18_set_level_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, float)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.float_)
     cg.add(var.set_level(template_))
     return var


### PR DESCRIPTION
## Problem

The `output.pi18.set_level` automation action has three bugs compared to the equivalent `output.pipsolar.set_level` action in pip8048:

1. **Wrong type argument in `cv.use_id`**: `cv.use_id(CONF_ID)` passes the string literal `"id"` as the type, not the `PipsolarOutput` class. ESPHome cannot validate the type of the referenced component, which can cause silent failures or confusing errors at compile time.

2. **Missing `synchronous=True`**: Without this flag the action runs asynchronously. For a serial command queue this is incorrect — the action must complete before the automation continues.

3. **`float` instead of `cg.float_`**: Python's built-in `float` was used instead of ESPHome's `cg.float_` C++ type in the `cg.templatable` call.

## Changes

- `components/pi18/output/__init__.py`: fix all three issues to match the pip8048 implementation

## Related issues

- #71 — user reported `output.pi18.set_level` producing malformed commands; the command format itself was fixed earlier, but these action registration bugs remained