### PR TITLE
Filter local UART echo in pip8048 component

### DIFF
--- a/components/pip8048/pipsolar.cpp
+++ b/components/pip8048/pipsolar.cpp
@@ -123,6 +123,18 @@ void Pipsolar::loop() {
         // end of answer
         if (byte == 0x0D) {
           this->read_buffer_[this->read_pos_] = 0;
+
+          // Echo filter: a legitimate Q-protocol response always starts with '(' (0x28).
+          // If the frame starts with anything else, it is the local echo of the command
+          // we just sent (looped back through the inverter's communication board) or
+          // line noise. Discard it and keep reading for the real response.
+          if (this->read_buffer_[0] != '(') {
+            ESP_LOGV(TAG, "Discarding %zu-byte non-response frame (likely echo): %s", this->read_pos_ - 1,
+                     this->read_buffer_);
+            this->read_pos_ = 0;
+            continue;
+          }
+
           this->empty_uart_buffer_();
           if (this->state_ == STATE_POLL) {
             this->state_ = STATE_POLL_COMPLETE;


### PR DESCRIPTION
## Summary

Some Voltronic-compatible inverters (e.g. Powmr 4.2KW with built-in BL602 WiFi module, reported in #231) loop transmitted bytes back to the receive line. Every poll command is echoed before the real response arrives. The echo carries the original CRC we appended, so it passes CRC validation and gets handed to the response parser as garbage data — no sensor values are extracted.

This change discards local echoes inside the pip8048 byte-reading loop, using a hard protocol invariant: legitimate Q-protocol responses always start with `(` (0x28), while echoes start with the command's first character (`Q`, `D`, `^`). When a complete frame (terminated by `\r`) does not start with `(`, the buffer is reset and reading continues — the UART RX buffer is intentionally not drained, so the real response remains readable.

Example with the reporter's inverter:

```
>>> QPIRI\xF8T\r              # outgoing poll
<<< QPIRI\xF8T\r              # echo  → first byte 'Q' ≠ '(' → discarded
<<< (230.0 10.0 ...\r         # real response → parsed normally
```

The discard is logged at `VERBOSE` level so it stays out of the default debug stream (echo would otherwise spam one line per poll) but remains available for diagnosis.

Refs #231

## Test plan

- [x] `pre-commit run --all-files` — all hooks green (clang-format included)
- [x] `esphome compile esp32-pip8048-example-faker.yaml` — builds cleanly with ESPHome 2026.5.0
- [ ] Field test by issue reporter on the affected Powmr 4.2KW unit
