### PR TITLE
Send CR after 3 consecutive poll timeouts to recover inverter UART

### DIFF
--- a/components/pip2424mse1/pipsolar.cpp
+++ b/components/pip2424mse1/pipsolar.cpp
@@ -85,6 +85,7 @@ void Pipsolar::loop() {
         return;
       }
       // crc ok
+      this->consecutive_timeouts_ = 0;
       this->enabled_polling_commands_[this->last_polling_command_].needs_update = false;
       this->state_ = STATE_POLL_CHECKED;
       return;
@@ -156,6 +157,11 @@ void Pipsolar::loop() {
       // command timeout
       ESP_LOGD(TAG, "poll %s timeout", this->enabled_polling_commands_[this->last_polling_command_].command);
       this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
+      if (++this->consecutive_timeouts_ >= 3) {
+        this->write(0x0D);
+        this->consecutive_timeouts_ = 0;
+        ESP_LOGW(TAG, "multiple timeouts, sending CR to recover inverter communication");
+      }
       this->state_ = STATE_IDLE;
     }
   }

--- a/components/pip2424mse1/pipsolar.h
+++ b/components/pip2424mse1/pipsolar.h
@@ -258,6 +258,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   };
 
   uint8_t last_polling_command_ = 0;
+  uint8_t consecutive_timeouts_ = 0;
   PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
 };
 


### PR DESCRIPTION
## Problem

When the inverter's serial parser gets stuck mid-frame (e.g. due to line noise or a power glitch), it ignores all subsequent commands. The symptom is continuous poll timeouts in the log. An ESP32 reboot doesn't help because the inverter is still waiting to complete the old frame — only physically disconnecting the data cable resets it (reported in #234).

## Fix

Track consecutive poll timeouts. After 3 in a row, send a bare `0x0D` (CR). Since `0x0D` is the frame terminator, the inverter tries to parse whatever is in its buffer, fails the CRC check, discards it, and returns to a ready state.

The counter resets on any successful poll response.

## Notes

- Change is limited to `pip2424mse1` component (same protocol as Easun SMH III affected in #234)
- Whether the inverter actually discards on CRC failure vs. hanging further depends on its firmware — this is a best-effort recovery with no downside if it doesn't help