### PR TITLE
Add battery voltage select examples to pip8048 configs

### DIFF
--- a/esp32-pip8048-powmr-4200w.yaml
+++ b/esp32-pip8048-powmr-4200w.yaml
@@ -307,6 +307,112 @@ select:
         "110": "110A"
         "120": "120A"
     # charging_discharging_control removed: requires QBATCD, not supported by POWMR 4200W
+    battery_type:
+      name: "battery type"
+      optionsmap:
+        "AGM": "PBT00"
+        "Flooded": "PBT01"
+        "User": "PBT02"
+        "Pylontech": "PBT09"
+      statusmap:
+        "0": "AGM"
+        "1": "Flooded"
+        "2": "User"
+        "9": "Pylontech"
+    battery_recharge_voltage:
+      name: "battery recharge voltage"
+      optionsmap:
+        "44.0V": "PBCV44.0"
+        "45.0V": "PBCV45.0"
+        "46.0V": "PBCV46.0"
+        "47.0V": "PBCV47.0"
+        "48.0V": "PBCV48.0"
+      statusmap:
+        "44.0": "44.0V"
+        "45.0": "45.0V"
+        "46.0": "46.0V"
+        "47.0": "47.0V"
+        "48.0": "48.0V"
+    battery_redischarge_voltage:
+      name: "battery redischarge voltage"
+      optionsmap:
+        "48.0V": "PBDV48.0"
+        "49.0V": "PBDV49.0"
+        "50.0V": "PBDV50.0"
+        "51.0V": "PBDV51.0"
+      statusmap:
+        "48.0": "48.0V"
+        "49.0": "49.0V"
+        "50.0": "50.0V"
+        "51.0": "51.0V"
+    battery_cutoff_voltage:
+      name: "battery cutoff voltage"
+      optionsmap:
+        "40.0V": "PSDV40.0"
+        "41.0V": "PSDV41.0"
+        "42.0V": "PSDV42.0"
+        "43.0V": "PSDV43.0"
+        "44.0V": "PSDV44.0"
+      statusmap:
+        "40.0": "40.0V"
+        "41.0": "41.0V"
+        "42.0": "42.0V"
+        "43.0": "43.0V"
+        "44.0": "44.0V"
+    battery_bulk_voltage:
+      name: "battery bulk voltage"
+      optionsmap:
+        "56.4V": "PCVV56.4"
+        "57.6V": "PCVV57.6"
+        "58.4V": "PCVV58.4"
+      statusmap:
+        "56.4": "56.4V"
+        "57.6": "57.6V"
+        "58.4": "58.4V"
+    battery_float_voltage:
+      name: "battery float voltage"
+      optionsmap:
+        "54.0V": "PBFT54.0"
+        "55.2V": "PBFT55.2"
+        "56.4V": "PBFT56.4"
+        "57.6V": "PBFT57.6"
+      statusmap:
+        "54.0": "54.0V"
+        "55.2": "55.2V"
+        "56.4": "56.4V"
+        "57.6": "57.6V"
+    battery_max_bulk_charging_time:
+      name: "battery max bulk charging time"
+      optionsmap:
+        "60min": "PCVT060"
+        "120min": "PCVT120"
+        "180min": "PCVT180"
+        "240min": "PCVT240"
+      statusmap:
+        "60": "60min"
+        "120": "120min"
+        "180": "180min"
+        "240": "240min"
+    max_discharging_current:
+      name: "max discharging current"
+      optionsmap:
+        "0A (disabled)": "PBATMAXDISC000"
+        "10A": "PBATMAXDISC010"
+        "20A": "PBATMAXDISC020"
+        "30A": "PBATMAXDISC030"
+        "40A": "PBATMAXDISC040"
+        "50A": "PBATMAXDISC050"
+      statusmap:
+        "0": "0A (disabled)"
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+    bms_values:
+      name: "bms values"
+      optionsmap:
+        "1 100 0 1 1 560 560 480 500 500": "PBMS1 100 0 1 1 560 560 480 500 500"
 
 switch:
   - platform: pip8048

--- a/esp8266-pip8048-example.yaml
+++ b/esp8266-pip8048-example.yaml
@@ -334,6 +334,112 @@ select:
         "(100": "100"
         "(001": "001"
         "(000": "000"
+    battery_type:
+      name: "battery type"
+      optionsmap:
+        "AGM": "PBT00"
+        "Flooded": "PBT01"
+        "User": "PBT02"
+        "Pylontech": "PBT09"
+      statusmap:
+        "0": "AGM"
+        "1": "Flooded"
+        "2": "User"
+        "9": "Pylontech"
+    battery_recharge_voltage:
+      name: "battery recharge voltage"
+      optionsmap:
+        "44.0V": "PBCV44.0"
+        "45.0V": "PBCV45.0"
+        "46.0V": "PBCV46.0"
+        "47.0V": "PBCV47.0"
+        "48.0V": "PBCV48.0"
+      statusmap:
+        "44.0": "44.0V"
+        "45.0": "45.0V"
+        "46.0": "46.0V"
+        "47.0": "47.0V"
+        "48.0": "48.0V"
+    battery_redischarge_voltage:
+      name: "battery redischarge voltage"
+      optionsmap:
+        "48.0V": "PBDV48.0"
+        "49.0V": "PBDV49.0"
+        "50.0V": "PBDV50.0"
+        "51.0V": "PBDV51.0"
+      statusmap:
+        "48.0": "48.0V"
+        "49.0": "49.0V"
+        "50.0": "50.0V"
+        "51.0": "51.0V"
+    battery_cutoff_voltage:
+      name: "battery cutoff voltage"
+      optionsmap:
+        "40.0V": "PSDV40.0"
+        "41.0V": "PSDV41.0"
+        "42.0V": "PSDV42.0"
+        "43.0V": "PSDV43.0"
+        "44.0V": "PSDV44.0"
+      statusmap:
+        "40.0": "40.0V"
+        "41.0": "41.0V"
+        "42.0": "42.0V"
+        "43.0": "43.0V"
+        "44.0": "44.0V"
+    battery_bulk_voltage:
+      name: "battery bulk voltage"
+      optionsmap:
+        "56.4V": "PCVV56.4"
+        "57.6V": "PCVV57.6"
+        "58.4V": "PCVV58.4"
+      statusmap:
+        "56.4": "56.4V"
+        "57.6": "57.6V"
+        "58.4": "58.4V"
+    battery_float_voltage:
+      name: "battery float voltage"
+      optionsmap:
+        "54.0V": "PBFT54.0"
+        "55.2V": "PBFT55.2"
+        "56.4V": "PBFT56.4"
+        "57.6V": "PBFT57.6"
+      statusmap:
+        "54.0": "54.0V"
+        "55.2": "55.2V"
+        "56.4": "56.4V"
+        "57.6": "57.6V"
+    battery_max_bulk_charging_time:
+      name: "battery max bulk charging time"
+      optionsmap:
+        "60min": "PCVT060"
+        "120min": "PCVT120"
+        "180min": "PCVT180"
+        "240min": "PCVT240"
+      statusmap:
+        "60": "60min"
+        "120": "120min"
+        "180": "180min"
+        "240": "240min"
+    max_discharging_current:
+      name: "max discharging current"
+      optionsmap:
+        "0A (disabled)": "PBATMAXDISC000"
+        "10A": "PBATMAXDISC010"
+        "20A": "PBATMAXDISC020"
+        "30A": "PBATMAXDISC030"
+        "40A": "PBATMAXDISC040"
+        "50A": "PBATMAXDISC050"
+      statusmap:
+        "0": "0A (disabled)"
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+    bms_values:
+      name: "bms values"
+      optionsmap:
+        "1 100 0 1 1 560 560 480 500 500": "PBMS1 100 0 1 1 560 560 480 500 500"
 
 switch:
   - platform: pip8048

--- a/esp8266-pip8048-powmr-4200w.yaml
+++ b/esp8266-pip8048-powmr-4200w.yaml
@@ -305,6 +305,112 @@ select:
         "110": "110A"
         "120": "120A"
     # charging_discharging_control removed: requires QBATCD, not supported by POWMR 4200W
+    battery_type:
+      name: "battery type"
+      optionsmap:
+        "AGM": "PBT00"
+        "Flooded": "PBT01"
+        "User": "PBT02"
+        "Pylontech": "PBT09"
+      statusmap:
+        "0": "AGM"
+        "1": "Flooded"
+        "2": "User"
+        "9": "Pylontech"
+    battery_recharge_voltage:
+      name: "battery recharge voltage"
+      optionsmap:
+        "44.0V": "PBCV44.0"
+        "45.0V": "PBCV45.0"
+        "46.0V": "PBCV46.0"
+        "47.0V": "PBCV47.0"
+        "48.0V": "PBCV48.0"
+      statusmap:
+        "44.0": "44.0V"
+        "45.0": "45.0V"
+        "46.0": "46.0V"
+        "47.0": "47.0V"
+        "48.0": "48.0V"
+    battery_redischarge_voltage:
+      name: "battery redischarge voltage"
+      optionsmap:
+        "48.0V": "PBDV48.0"
+        "49.0V": "PBDV49.0"
+        "50.0V": "PBDV50.0"
+        "51.0V": "PBDV51.0"
+      statusmap:
+        "48.0": "48.0V"
+        "49.0": "49.0V"
+        "50.0": "50.0V"
+        "51.0": "51.0V"
+    battery_cutoff_voltage:
+      name: "battery cutoff voltage"
+      optionsmap:
+        "40.0V": "PSDV40.0"
+        "41.0V": "PSDV41.0"
+        "42.0V": "PSDV42.0"
+        "43.0V": "PSDV43.0"
+        "44.0V": "PSDV44.0"
+      statusmap:
+        "40.0": "40.0V"
+        "41.0": "41.0V"
+        "42.0": "42.0V"
+        "43.0": "43.0V"
+        "44.0": "44.0V"
+    battery_bulk_voltage:
+      name: "battery bulk voltage"
+      optionsmap:
+        "56.4V": "PCVV56.4"
+        "57.6V": "PCVV57.6"
+        "58.4V": "PCVV58.4"
+      statusmap:
+        "56.4": "56.4V"
+        "57.6": "57.6V"
+        "58.4": "58.4V"
+    battery_float_voltage:
+      name: "battery float voltage"
+      optionsmap:
+        "54.0V": "PBFT54.0"
+        "55.2V": "PBFT55.2"
+        "56.4V": "PBFT56.4"
+        "57.6V": "PBFT57.6"
+      statusmap:
+        "54.0": "54.0V"
+        "55.2": "55.2V"
+        "56.4": "56.4V"
+        "57.6": "57.6V"
+    battery_max_bulk_charging_time:
+      name: "battery max bulk charging time"
+      optionsmap:
+        "60min": "PCVT060"
+        "120min": "PCVT120"
+        "180min": "PCVT180"
+        "240min": "PCVT240"
+      statusmap:
+        "60": "60min"
+        "120": "120min"
+        "180": "180min"
+        "240": "240min"
+    max_discharging_current:
+      name: "max discharging current"
+      optionsmap:
+        "0A (disabled)": "PBATMAXDISC000"
+        "10A": "PBATMAXDISC010"
+        "20A": "PBATMAXDISC020"
+        "30A": "PBATMAXDISC030"
+        "40A": "PBATMAXDISC040"
+        "50A": "PBATMAXDISC050"
+      statusmap:
+        "0": "0A (disabled)"
+        "10": "10A"
+        "20": "20A"
+        "30": "30A"
+        "40": "40A"
+        "50": "50A"
+    bms_values:
+      name: "bms values"
+      optionsmap:
+        "1 100 0 1 1 560 560 480 500 500": "PBMS1 100 0 1 1 560 560 480 500 500"
 
 switch:
   - platform: pip8048


### PR DESCRIPTION
## Summary

- Documents `battery_float_voltage` (PBFT), `battery_recharge_voltage` (PBCV), `battery_redischarge_voltage` (PBDV), `battery_cutoff_voltage` (PSDV), `battery_bulk_voltage` (PCVV), `battery_type` (PBT), `battery_max_bulk_charging_time` (PCVT), `max_discharging_current` (PBATMAXDISC), and `bms_values` (PBMS) select entities in the three pip8048 example configs that were missing them
- `esp32-pip8048-example.yaml` already had all these entries; this PR aligns `esp8266-pip8048-example.yaml`, `esp8266-pip8048-powmr-4200w.yaml` and `esp32-pip8048-powmr-4200w.yaml`
- All select entities were already fully implemented in Python and C++ — only the YAML documentation was missing

Closes #144

## Root cause

Issue #144 shows a user trying to control the float charging voltage by abusing the `current_max_ac_charging_current` entity to send `PBFT` commands. The proper `battery_float_voltage` select entity was implemented but not shown in the example YAML, so users didn't know it existed.

## Test plan

- [ ] YAML linting passes (no output from `yamllint`)
- [ ] Verify `battery_float_voltage` select shows current value from QPIRI response correctly
- [ ] Verify sending a PBFT command via the select changes the inverter setting